### PR TITLE
Solve typo in webpack configuration

### DIFF
--- a/packages/leemons-react/config/webpack.config.js
+++ b/packages/leemons-react/config/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = ({ alias, filesToCopy, useLegacy = false }) => ({
     pathinfo: isDev,
     // There will be one main bundle, and one file per asynchronous chunk.
     // In development, it does not produce real files.
-    filename: isProduction ? 'static/js/[name].[contentHash:8].js' : 'static/js/bundle.js',
+    filename: isProduction ? 'static/js/[name].[contenthash:8].js' : 'static/js/bundle.js',
     // There are also additional JS chunk files if you use code splitting.
     chunkFilename: isProduction
       ? 'static/js/[name].[contenthash:8].chunk.js'


### PR DESCRIPTION
Currently the javascript bundles are being generated without a valid contenthash however the css is being generated correctly. This is due to a typo in the configuration.

<img width="793" alt="Captura de Pantalla 2022-07-20 a las 18 30 38" src="https://user-images.githubusercontent.com/385840/180037350-c9d08c47-021f-4a02-838a-ef9038d2ac95.png">

I have tested the change and now generate the js filenames correctly.