### PR TITLE
mysql-adapted-to-apple-chip

### DIFF
--- a/docker/docker-compose-apple-chip.yaml
+++ b/docker/docker-compose-apple-chip.yaml
@@ -1,0 +1,83 @@
+version: "3.8"
+services:
+  leemons-yarn-install:
+    image: node:16
+    profiles:
+      - installation
+    volumes:
+      - ./src/package.json:/monorepo/package.json
+      - ../examples/docker:/monorepo/app
+      - ../packages:/monorepo/packages
+      - ../examples/docker/monorepo_node_modules:/monorepo/node_modules
+      - ../examples/docker/monorepo_yarn.lock:/monorepo/yarn.lock
+      - ./src/installDeps.sh:/monorepo/installDeps.sh
+      - ./src/retry.sh:/monorepo/retry.sh
+      - ./src/app/package.json:/monorepo/appPackageTemplate.json
+    working_dir: /monorepo
+    tty: true
+    stdin_open: true
+    command: sh retry.sh ./installDeps.sh
+
+  leemons-back:
+    image: node:16
+    tty: true
+    stdin_open: true
+    volumes:
+      - ./src/package.json:/monorepo/package.json
+      - ../examples/docker:/monorepo/app
+      - ../packages:/monorepo/packages
+      - ../examples/docker/monorepo_node_modules:/monorepo/node_modules
+      - ../yarn.lock:/monorepo/yarn.lock
+      - ./src/retry.sh:/monorepo/retry.sh
+    links:
+      - mysql
+      - leemons-front
+    working_dir: /monorepo/app
+    command: sh ../retry.sh FRONT_SERVER=http://leemons-front:3000 yarn start
+    ports:
+      - 8080:8080
+    depends_on:
+      mysql:
+        condition: service_healthy
+
+  leemons-front:
+    image: node:16
+    tty: true
+    stdin_open: true
+    volumes:
+      - ./src/package.json:/monorepo/package.json
+      - ../packages:/monorepo/packages
+      - ../examples/docker/monorepo_node_modules:/monorepo/node_modules
+      - ../examples/docker:/monorepo/app
+      - ../yarn.lock:/monorepo/yarn.lock
+      - ./src/front/build.sh:/monorepo/build.sh
+      - ./src/retry.sh:/monorepo/retry.sh
+    working_dir: /monorepo
+    restart: always
+    expose:
+      - 3000
+    ports:
+      - 3000:3000
+    command: sh ./retry.sh sh ./build.sh
+
+  mysql:
+    platform: linux/x86_64
+    image: mysql
+    command: --default-authentication-plugin=mysql_native_password
+    restart: always
+    environment:
+      MYSQL_DATABASE: $DATABASE_DATABASE
+      MYSQL_USER: $DATABASE_USERNAME
+      MYSQL_PASSWORD: $DATABASE_PASSWORD
+      MYSQL_ROOT_PASSWORD: $DATABASE_PASSWORD
+    cap_add:
+      - SYS_NICE
+    expose:
+      - 3306
+    ports:
+      - 3307:3306
+
+    healthcheck:
+      test: mysqladmin ping -h 127.0.0.1 -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
When I tried to instal via docker, I couldn't. 

It was because the Platform was not described on docker compose.
Message: Mysql is not in entrie list. 

Solution
Describe on mysql service, the platform with the line at the same level and before the image platform: linux/x86_64

Solved and working on iMac 24" with M1 Apple Chip.