### PR TITLE
fix: handle empty array case of authorization in auth middleware

### DIFF
--- a/packages/leemons/lib/leemons.js
+++ b/packages/leemons/lib/leemons.js
@@ -259,7 +259,7 @@ class Leemons {
             ctx.state.userSession = user;
             return next();
           }
-        } else {
+        } else if (!_.isEmpty(authorization)) {
           authorization = _.compact(authorization);
           const user = await this.plugins.users.services.users.detailForJWT(authorization[0], true);
           const userAgents = await Promise.all(


### PR DESCRIPTION
![image](https://github.com/leemonade/leemons/assets/66194265/27ad9415-a723-4af0-ae8f-6f191a64c1be)

There is a case when authorization is empty but it still go through the JWT verify process. That caused issue `JWT must be Provided`

Issue: https://github.com/leemonade/leemons/issues/87