### PR TITLE
Library - Texto en modal de duplicar

### DIFF
--- a/plugins/leemons-plugin-layout/backend/i18n/en.js
+++ b/plugins/leemons-plugin-layout/backend/i18n/en.js
@@ -2,11 +2,12 @@ module.exports = {
   modals: {
     title: {
       delete: 'Confirm delete',
-      confirm: 'Important',
+      confirm: 'Confirm duplicate',
     },
     description: {
       delete: 'The item will be deleted, do you want to proceed?',
-      confirm: 'Do you want to proceed?',
+      confirm:
+        'When duplicate, a copy of this item will be created, but the permission settings will be lost.',
     },
     buttons: {
       cancel: 'Cancel',

--- a/plugins/leemons-plugin-layout/backend/i18n/es.js
+++ b/plugins/leemons-plugin-layout/backend/i18n/es.js
@@ -2,11 +2,12 @@ module.exports = {
   modals: {
     title: {
       delete: 'Confirmar eliminación',
-      confirm: 'Importante',
+      confirm: 'Confirmar duplicar',
     },
     description: {
       delete: 'El ítem será borrado, ¿deseas proceder?',
-      confirm: '¿Deseas continuar?',
+      confirm:
+        'Al duplicar se creará una copia de este ítem, pero se perderá la configuración de permisos.',
     },
     buttons: {
       cancel: 'Cancelar',

--- a/plugins/leemons-plugin-layout/frontend/globalContext.js
+++ b/plugins/leemons-plugin-layout/frontend/globalContext.js
@@ -36,7 +36,7 @@ function useLayoutProviderModals() {
   const [t] = useTranslateLoader(prefixPN('modals'));
 
   const openConfirmationModal = useCallback(
-    ({ title, description, labels, onCancel = () => { }, onConfirm = () => { } }) =>
+    ({ title, description, labels, onCancel = () => {}, onConfirm = () => {} }) =>
       () =>
         modals.openConfirmModal({
           title: title || t('title.confirm'),
@@ -48,7 +48,7 @@ function useLayoutProviderModals() {
               dangerouslySetInnerHTML={{ __html: description || t('description.confirm') }}
             />
           ) : (
-            description
+            description || t('description.confirm')
           ),
           labels: {
             confirm: labels?.confirm || t('buttons.confirm'),
@@ -61,7 +61,7 @@ function useLayoutProviderModals() {
   );
 
   const openDeleteConfirmationModal = useCallback(
-    ({ title, description, labels, onCancel = () => { }, onConfirm = () => { } }) =>
+    ({ title, description, labels, onCancel = () => {}, onConfirm = () => {} }) =>
       () =>
         modals.openConfirmModal({
           title: title || t('title.delete', { 'title.delete': 'Esta muriendo' }),


### PR DESCRIPTION
We have fixed the modal logic to display the message body. We have also placed the new title and body of the message and their corresponding translations.