### PR TITLE
Test: send right cover data to assignables

### DIFF
--- a/plugins/leemons-plugin-tests/frontend/src/pages/private/tests/Edit.js
+++ b/plugins/leemons-plugin-tests/frontend/src/pages/private/tests/Edit.js
@@ -63,6 +63,7 @@ export default function Edit() {
 
       const { subjects, ...toSend } = formValues;
       toSend.subjects = subjects?.map((subject) => (isString(subject) ? subject : subject.subject));
+      toSend.cover = toSend.cover?.id ?? toSend.cover;
 
       const { test } = await saveTestRequest({ ...toSend, type: 'learn', published: false });
       addSuccessAlert(t('savedAsDraft'));
@@ -82,6 +83,8 @@ export default function Edit() {
       render();
       const { subjects, ...toSend } = formValues;
       toSend.subjects = subjects?.map((subject) => (isString(subject) ? subject : subject.subject));
+      toSend.cover = toSend.cover?.id ?? toSend.cover;
+
       const { test } = await saveTestRequest({ ...toSend, type: 'learn', published: true });
       addSuccessAlert(t('published'));
       if (redictToAssign) {


### PR DESCRIPTION
Fix test can't be published once saved as draft.

The problem was the tests frontend was sending full cover url instead of cover id.