### PR TITLE
Issue/ccreator draft saving

### DIFF
--- a/plugins/leemons-plugin-academic-portfolio/frontend/src/components/SubjectItemDisplay/SubjectItemDisplay.js
+++ b/plugins/leemons-plugin-academic-portfolio/frontend/src/components/SubjectItemDisplay/SubjectItemDisplay.js
@@ -40,6 +40,8 @@ const SubjectItemDisplay = ({ subjectsIds, programId }) => {
       typeof subjectsIds[0] === 'string'
     ) {
       setSubjectData(preparedSubject?.data?.[0]);
+    } else if (subjectData !== null) {
+      setSubjectData(null);
     }
     if (!isArray(subjectsIds) && subjectsIds?.name)
       setSubjectData({
@@ -49,7 +51,9 @@ const SubjectItemDisplay = ({ subjectsIds, programId }) => {
       });
   }, [isMultiSubjectCase, preparedSubject.data, subjectsIds]);
   useEffect(() => {
-    if (programData) {
+    if (!programId) {
+      setProgramName(null);
+    } else if (programData) {
       setProgramName(programData?.name);
     } else if (typeof programId === 'string' && !programId.includes('lrn:')) {
       setProgramName(programId);

--- a/plugins/leemons-plugin-content-creator/frontend/src/pages/Detail/index.js
+++ b/plugins/leemons-plugin-content-creator/frontend/src/pages/Detail/index.js
@@ -146,8 +146,7 @@ export default function Index({ isNew, readOnly }) {
   // INITIAL DATA HANDLER
 
   useEffect(() => {
-    // Temporary fix. There's a discrepancy between how multiple subjects and their corresponding programs are stored.
-    // It appears these tags were not intended to support multiple programs. Needs to be updated.
+    // Temporary fix. It won't be needed to solved the program if the Suject Picker limits the options to one program
     let solvedProgram;
     if (documentData?.subjects?.length) {
       solvedProgram = documentData?.subjects[0].program;

--- a/plugins/leemons-plugin-content-creator/frontend/src/pages/Detail/index.js
+++ b/plugins/leemons-plugin-content-creator/frontend/src/pages/Detail/index.js
@@ -146,6 +146,12 @@ export default function Index({ isNew, readOnly }) {
   // INITIAL DATA HANDLER
 
   useEffect(() => {
+    // Temporary fix. There's a discrepancy between how multiple subjects and their corresponding programs are stored.
+    // It appears these tags were not intended to support multiple programs. Needs to be updated.
+    let solvedProgram;
+    if (documentData?.subjects?.length) {
+      solvedProgram = documentData?.subjects[0].program;
+    }
     if (isNew) form.reset();
     else {
       form.setValue('name', documentData?.name);
@@ -153,8 +159,8 @@ export default function Index({ isNew, readOnly }) {
       form.setValue('description', documentData?.description);
       form.setValue('color', documentData?.color || null);
       form.setValue('cover', documentData?.cover || null);
-      form.setValue('program', documentData?.program || null);
-      form.setValue('subjects', documentData?.subjects || null);
+      form.setValue('program', documentData?.program || solvedProgram || null);
+      form.setValue('subjects', documentData?.subjects?.map((subject) => subject.subject) || null);
     }
   }, [documentData]);
 

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetForm/AssetForm.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetForm/AssetForm.js
@@ -277,8 +277,6 @@ const AssetForm = ({
 
   if (store.alwaysOpen) store.showAdvancedConfig = true;
 
-  console.log('formValues.program', formValues?.program);
-
   return (
     <Box ref={boxRef}>
       <form autoComplete="off">

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetForm/AssetForm.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetForm/AssetForm.js
@@ -201,6 +201,13 @@ const AssetForm = ({
     onChange(formValues);
   }, [formValues]);
 
+  useEffect(() => {
+    if (formValues?.subjects?.length && !store.showAdvancedConfig) {
+      store.showAdvancedConfig = true;
+      render();
+    }
+  }, [formValues?.subjects]);
+
   // ························································
   // HANDLERS
 
@@ -269,6 +276,8 @@ const AssetForm = ({
   }, [type, urlMetadata]);
 
   if (store.alwaysOpen) store.showAdvancedConfig = true;
+
+  console.log('formValues.program', formValues?.program);
 
   return (
     <Box ref={boxRef}>

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/LibraryCardBody/LibraryCardBody.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/LibraryCardBody/LibraryCardBody.js
@@ -64,6 +64,8 @@ const LibraryCardBody = ({
       setSubjectData(subjectIds);
     } else if (!isArray(subjects) && subjects?.name) {
       setSubjectData(subjects);
+    } else if (subjectData !== null) {
+      setSubjectData(null);
     }
   }, [subjects]);
 

--- a/plugins/leemons-plugin-leebrary/frontend/src/pages/private/assets/AssetPage.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/pages/private/assets/AssetPage.js
@@ -195,7 +195,6 @@ const AssetPage = () => {
     try {
       const body = { ...formValues };
       if (category?.key !== 'bookmarks' && !body.file?.id) {
-        console.log('1');
         if (
           body.file.type.startsWith('image') &&
           body.file.type.indexOf('/gif') < 0 &&
@@ -226,7 +225,6 @@ const AssetPage = () => {
 
       try {
         const assetData = { ...body, cover, file: body.file?.id ?? file };
-        console.log('file', file);
         const needsOldCover = isImage
           ? form.formState.dirtyFields.file
           : form.formState.dirtyFields.cover;
@@ -243,7 +241,6 @@ const AssetPage = () => {
             setUploadingFileInfo(info);
           },
         });
-        console.log('PASAMOS LA REQUEST');
         const response = await getAssetRequest(newAsset.id);
         setAsset(prepareAsset(response.asset));
         setLoading(false);
@@ -258,19 +255,16 @@ const AssetPage = () => {
           history.push('/private/leebrary/bookmarks/list');
         else history.push('/private/leebrary/media-files/list');
       } catch (err) {
-        console.log('err', err);
         setLoading(false);
         addErrorAlert(getErrorMessage(err));
       }
     } catch (e) {
-      console.log('e', e);
       setUploadingFileInfo(null);
     }
   };
 
   const handlePlublishAndAssign = async () => {
     await handlePublish();
-    // console.log('REDIRECCIÓN A ASIGNAR');
   };
   // #endregion
 

--- a/plugins/leemons-plugin-leebrary/frontend/src/pages/private/assets/AssetPage.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/pages/private/assets/AssetPage.js
@@ -63,7 +63,7 @@ const AssetPage = () => {
     cover: asset?.cover || null,
     url: asset?.url || null,
     program: asset?.program || null,
-    subjects: asset?.subjects || null,
+    subjects: asset?.subjects?.map((subject) => subject?.subject) || null,
     tags: asset?.tags || [],
   });
 

--- a/plugins/leemons-plugin-leebrary/frontend/src/pages/private/assets/AssetPage.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/pages/private/assets/AssetPage.js
@@ -194,33 +194,39 @@ const AssetPage = () => {
 
     try {
       const body = { ...formValues };
-      if (category?.key !== 'bookmarks') {
+      if (category?.key !== 'bookmarks' && !body.file?.id) {
+        console.log('1');
         if (
           body.file.type.startsWith('image') &&
           body.file.type.indexOf('/gif') < 0 &&
           body.file.type.indexOf('/svg') < 0
         ) {
           const fileName = body.file.name;
+
           const resizedImage = await readAndCompressImage(body.file, {
             quality: 0.8,
             maxWidth: 800,
             maxHeight: 600,
             debug: true,
           });
+
           body.file = resizedImage;
           body.file.name = fileName;
         }
         setUploadingFileInfo({ state: t('common.labels.processingImage') });
+
         file = await uploadFileAsMultipart(body.file, {
           onProgress: (info) => {
             setUploadingFileInfo(info);
           },
         });
+
         setUploadingFileInfo(null);
       }
 
       try {
-        const assetData = { ...body, cover, file };
+        const assetData = { ...body, cover, file: body.file?.id ?? file };
+        console.log('file', file);
         const needsOldCover = isImage
           ? form.formState.dirtyFields.file
           : form.formState.dirtyFields.cover;
@@ -237,6 +243,7 @@ const AssetPage = () => {
             setUploadingFileInfo(info);
           },
         });
+        console.log('PASAMOS LA REQUEST');
         const response = await getAssetRequest(newAsset.id);
         setAsset(prepareAsset(response.asset));
         setLoading(false);
@@ -251,10 +258,12 @@ const AssetPage = () => {
           history.push('/private/leebrary/bookmarks/list');
         else history.push('/private/leebrary/media-files/list');
       } catch (err) {
+        console.log('err', err);
         setLoading(false);
         addErrorAlert(getErrorMessage(err));
       }
     } catch (e) {
+      console.log('e', e);
       setUploadingFileInfo(null);
     }
   };


### PR DESCRIPTION
Solves issue: Content creator documents cannot be edited (as drafts or published) after using a subject tag.
Media files had the same problem. It's fixed as well.

There's an issue when editing image assets which don't seem to be related to subject tagging.