### PR TITLE
fix(leebrary): Files & cover files management when editing/creating a media-files or bookmark asset

### DIFF
--- a/plugins/leemons-plugin-leebrary/backend/core/assets/update/handleFileAndCoverUpdates.js
+++ b/plugins/leemons-plugin-leebrary/backend/core/assets/update/handleFileAndCoverUpdates.js
@@ -27,26 +27,26 @@ async function handleFileAndCoverUpdates({
   const cover = assetData.cover || assetData.coverFile;
   const filesToRemove = [];
   let newFile;
-  let coverFile;
+  let newCoverFile;
 
   if (fileNeedsUpdate && !isEmpty(file)) {
     newFile = await uploadFromSource({ source: file, name: assetData.name, ctx });
 
     if (newFile?.type?.indexOf('image') === 0) {
-      coverFile = newFile;
-      filesToRemove.push(cover);
+      newCoverFile = newFile;
     }
 
     await addFiles({ fileId: newFile.id, assetId, ctx });
+    filesToRemove.push(currentAsset.file.id);
     delete updateObject.file;
   }
 
-  if (coverNeedsUpdate && !coverFile && !isEmpty(cover)) {
-    coverFile = await uploadFromSource({ source: cover, name: assetData.name, ctx });
+  if (coverNeedsUpdate && !newCoverFile && !isEmpty(cover)) {
+    newCoverFile = await uploadFromSource({ source: cover, name: assetData.name, ctx });
   }
 
-  if (coverFile?.id) {
-    updateObject.cover = coverFile.id;
+  if (newCoverFile?.id) {
+    updateObject.cover = newCoverFile.id;
   }
 
   // ES: En caso de que no hayan cambio en los archivos, los dejamos establecidos con su valor actual
@@ -55,11 +55,11 @@ async function handleFileAndCoverUpdates({
     newFile = currentAsset.file;
   }
 
-  if (!coverFile && !coverNeedsUpdate) {
-    coverFile = currentAsset.cover;
+  if (!newCoverFile && !coverNeedsUpdate) {
+    newCoverFile = currentAsset.cover;
   }
 
-  return { newFile, coverFile, toUpdate: updateObject, filesToRemove };
+  return { newFile, coverFile: newCoverFile, toUpdate: updateObject, filesToRemove };
 }
 
 module.exports = { handleFileAndCoverUpdates };

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetForm/AssetForm.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetForm/AssetForm.js
@@ -183,15 +183,15 @@ const AssetForm = ({
   }, [JSON.stringify(advancedConfig)]);
 
   useEffect(() => {
+    const isImageType = isImageFile(assetFile);
     if (!isEmpty(assetFile)) {
-      const isImageType = isImageFile(assetFile);
       setIsImage(isImageType);
       if (isEmpty(formValues.name)) {
         setValue('name', assetFile.name.match(/(.+?)(\.[^.]+$|$)/)[1]);
       }
-      if (isImageType) {
-        // setValue('cover', null);
-      }
+    }
+    if (isImageType) {
+      setValue('cover', assetFile);
     }
   }, [assetFile]);
 

--- a/plugins/leemons-plugin-leebrary/frontend/src/helpers/prepareAsset.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/helpers/prepareAsset.js
@@ -164,8 +164,6 @@ export function resolveAssetType(file, type, asset) {
   const resolvedFileType = ['audio', 'video', 'image', 'bookmark'].includes(fileType)
     ? fileType
     : defaultType;
-  const finalFileType =
-    resolvedFileType === 'file' && fileExtension ? fileExtension.toUpperCase() : resolvedFileType;
 
   return { fileType: resolvedFileType, fileExtension };
 }


### PR DESCRIPTION
- asset cover can be changed correctly
- asset file updates work correctly, only one file per asset 
- bookmarks save and update cover image correctly
- when editing, the cover value sent to de backend is a file id or null/undefined not a url