### PR TITLE
fix(library): set assets created through the AssetPickerDrawer as no indexable

### DIFF
--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetPickerDrawer/components/NewResource.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetPickerDrawer/components/NewResource.js
@@ -81,7 +81,7 @@ export function NewResource({ categories: creatableCategories, acceptedFileTypes
 
       try {
         const { asset } = await newAssetRequest(
-          { ...body, file: uploadedFile },
+          { ...body, file: uploadedFile, indexable: false },
           null,
           'media-files'
         );


### PR DESCRIPTION
Pass indexable parameter as false when creating an asset through the AssetPickerDrawer in order for it not to be listed in library.