### PR TITLE
fix(learning-paths): change AssetPickerDrawer layout to rows 

### DIFF
--- a/plugins/leemons-plugin-learning-paths/frontend/src/components/ModuleSetup/components/Resources/Resources.js
+++ b/plugins/leemons-plugin-learning-paths/frontend/src/components/ModuleSetup/components/Resources/Resources.js
@@ -119,7 +119,7 @@ export function Resources({ localizations, onPrevStep, scrollRef, onSave }) {
     >
       <Box>
         <AssetPickerDrawer
-          layout="cards"
+          layout="rows"
           categories={['media-files', 'bookmarks', 'assignables.content-creator']}
           creatable
           onClose={() => setShowAssetDrawer(false)}


### PR DESCRIPTION
...to show assets as a list instead of a grid