### PR TITLE
fix(CCreator): remove dashboardURL

### DIFF
--- a/plugins/leemons-plugin-content-creator/backend/config/constants.js
+++ b/plugins/leemons-plugin-content-creator/backend/config/constants.js
@@ -85,7 +85,6 @@ const assignableRoles = [
       teacherDetailUrl: '/private/content-creator/detail/:id',
       studentDetailUrl: '/private/content-creator/view/:id/:user',
       evaluationDetailUrl: '/private/content-creator/view/:id/:user',
-      dashboardUrl: '/private/content-creator/view/:id',
       previewUrl: '/private/content-creator/:id/view',
       creatable: true,
       order: 1,


### PR DESCRIPTION
dashboardURL is used for the student redirection to a dashboard of the activity, such as module dashboard, not to redirect it to the evaluation, review or execution pages