### PR TITLE
Asset Drawer - Extraño comportamiento

### DIFF
--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetEmbedList.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetEmbedList.js
@@ -55,7 +55,7 @@ const AssetEmbedList = ({ assets, width }) => {
     ids: assetIds,
     filters: {
       showPublic: true,
-      indexable: false,
+      indexable: null,
     },
     enabled: assetIds.length > 0,
   });
@@ -67,8 +67,13 @@ const AssetEmbedList = ({ assets, width }) => {
     return assetsData?.find((asset) => asset.id === assetId) || {};
   }
   const handleOnSelect = (item) => {
-    setSelectedAsset(item);
-    setIsDrawerOpen(true);
+    setIsDrawerOpen(false); // Siempre cierra el drawer primero
+
+    // Establece el activo seleccionado y luego abre el drawer después de un breve retraso
+    setTimeout(() => {
+      setSelectedAsset(item);
+      setIsDrawerOpen(true);
+    }, 100); // Un retraso de 100ms suele ser suficiente para este propósito
   };
   useEffect(() => {
     if (assets?.length) {
@@ -98,7 +103,10 @@ const AssetEmbedList = ({ assets, width }) => {
               isEmbeddedList={true}
               variant={'embedded'}
               assetsLoading={isLoading}
-              onClick={() => handleOnSelect(pickAsset(assetId))}
+              onClick={() => {
+
+                handleOnSelect(pickAsset(assetId))
+              }}
             />
           </Box>
         ))

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetEmbedList.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetEmbedList.js
@@ -36,7 +36,6 @@ const AssetEmbedList = ({ assets, width }) => {
   const session = useSession();
   const locale = getLocale(session);
 
-
   const detailLabels = useMemo(() => {
     if (!isEmpty(translations)) {
       const items = unflatten(translations.items);
@@ -87,29 +86,28 @@ const AssetEmbedList = ({ assets, width }) => {
     <Box className={classes.root}>
       {assetIds.length > 0
         ? assetIds.map((assetId) => (
-          <Box className={classes.item} key={assetId}>
-            <CardWrapper
-              {...pickAsset(assetId)}
-              isEmbedded={true}
-              item={pickAsset(assetId)}
-              category={
-                categoriesData?.find(
-                  (category) => category.id === pickAsset(assetId).category
-                ) || {
-                  key: 'media-file',
+            <Box className={classes.item} key={assetId}>
+              <CardWrapper
+                {...pickAsset(assetId)}
+                isEmbedded={true}
+                item={pickAsset(assetId)}
+                category={
+                  categoriesData?.find(
+                    (category) => category.id === pickAsset(assetId).category
+                  ) || {
+                    key: 'media-file',
+                  }
                 }
-              }
-              isCreationPreview={false}
-              isEmbeddedList={true}
-              variant={'embedded'}
-              assetsLoading={isLoading}
-              onClick={() => {
-
-                handleOnSelect(pickAsset(assetId))
-              }}
-            />
-          </Box>
-        ))
+                isCreationPreview={false}
+                isEmbeddedList={true}
+                variant={'embedded'}
+                assetsLoading={isLoading}
+                onClick={() => {
+                  handleOnSelect(pickAsset(assetId));
+                }}
+              />
+            </Box>
+          ))
         : null}
       <Box
         sx={() => ({

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetPlayer/AssetPlayer.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetPlayer/AssetPlayer.js
@@ -245,8 +245,7 @@ const AssetPlayer = ({
 
   useEffect(() => setFullScreenMode(fullScreen), [fullScreen]);
   useEffect(() => setIsPlaying(playing), [playing]);
-  useEffect(() => setMediaVolume(volume), [volume]);
-  useEffect(() => setMediaVolume(volume), [media]);
+  useEffect(() => setMediaVolume(volume), [volume, media]);
 
   useEffect(() => {
     document.body.addEventListener('keydown', toggleOnSpaceBar);

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetPlayer/AssetPlayer.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetPlayer/AssetPlayer.js
@@ -122,6 +122,7 @@ const AssetPlayer = ({
         isURL: false,
       };
     }
+    setShowPlayer(false);
     return result;
   }, [fileType, mediaType]);
 
@@ -245,6 +246,7 @@ const AssetPlayer = ({
   useEffect(() => setFullScreenMode(fullScreen), [fullScreen]);
   useEffect(() => setIsPlaying(playing), [playing]);
   useEffect(() => setMediaVolume(volume), [volume]);
+  useEffect(() => setMediaVolume(volume), [media]);
 
   useEffect(() => {
     document.body.addEventListener('keydown', toggleOnSpaceBar);
@@ -274,7 +276,6 @@ const AssetPlayer = ({
     },
     { name: 'AssetPlayer' }
   );
-
   return (
     <Box className={classes.rootWrapper}>
       <Box className={classes.root} ref={rootRef}>


### PR DESCRIPTION
 When a media change, set showPlayer state to false.  The issue we were having is that when an asset is of type video or audio and we played it, the showPlayer variable remained set to true, applying a pointerEvents: none to the parent layer that stayed set when we switched assets, preventing any clicks on the new asset whenever it was of a media type. With this implementation, we fixed the bug.