### PR TITLE
fix(learning-paths): Title changes don't reset the form

### DIFF
--- a/plugins/leemons-plugin-learning-paths/frontend/src/components/ModuleSetup/components/BasicData/BasicData.js
+++ b/plugins/leemons-plugin-learning-paths/frontend/src/components/ModuleSetup/components/BasicData/BasicData.js
@@ -102,11 +102,13 @@ export function BasicData({ localizations, scrollRef, onNextStep = noop, onSave 
   const [sharedData] = useModuleSetupContext();
   const form = useForm({ defaultValues: sharedData?.basicData ?? {} });
 
+  // When sharedData.basicData brings data from the server it will be updated
+  // Otherwise this is only used to handle the title changes and all fields are set in the sharedData.basicData object on submit
   useEffect(() => {
-    form.reset(sharedData?.basicData ?? {});
+    Object.keys(sharedData?.basicData ?? {}).forEach((key) => {
+      form.setValue(key, sharedData.basicData[key]);
+    });
   }, [sharedData?.basicData]);
-
-  const { classes } = useBasicDataStyles();
 
   const onSubmit = useOnSubmit({ handleSubmit: form.handleSubmit });
   useOnSave({ onSubmit });


### PR DESCRIPTION
SharedValues object is managed differently for it not to reset the form but set its values. This ensures the name field will not cause a form reset. Data from the server still loads correctly on edition.