### PR TITLE
fix(tests): scroll to the input element when adding answers in MonoResponse question types

### DIFF
--- a/plugins/leemons-plugin-tests/frontend/src/pages/private/questions-banks/components/DetailQuestionForm.js
+++ b/plugins/leemons-plugin-tests/frontend/src/pages/private/questions-banks/components/DetailQuestionForm.js
@@ -109,8 +109,9 @@ export default function DetailQuestionForm({
     return React.cloneElement(questionComponents[type], {
       form,
       t,
+      scrollRef,
     });
-  }, [type, form, t]);
+  }, [type, form, t, scrollRef]);
 
   const hideOptionsHelp = React.useMemo(() => {
     if (!rightAnswerSelected) return t('hideOptionNoRightAnswer');

--- a/plugins/leemons-plugin-tests/frontend/src/pages/private/questions-banks/components/DetailQuestions.js
+++ b/plugins/leemons-plugin-tests/frontend/src/pages/private/questions-banks/components/DetailQuestions.js
@@ -112,6 +112,7 @@ export default function DetailQuestions({
           ]);
         }}
         store={store}
+        scrollRef={scrollRef}
       />
     );
   }

--- a/plugins/leemons-plugin-tests/frontend/src/pages/private/questions-banks/components/question-types/MonoResponse/components/ListInputRender.js
+++ b/plugins/leemons-plugin-tests/frontend/src/pages/private/questions-banks/components/question-types/MonoResponse/components/ListInputRender.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import {
   InputWrapper,
@@ -21,6 +21,7 @@ export function ListInputRender({
   addItem,
   value,
   onCancel,
+  scrollRef,
   ...props
 }) {
   const [store, render] = useStore(value || { useButton: true });
@@ -95,7 +96,17 @@ export function ListInputRender({
     render();
   }
 
-  // const Container = store.useButton ? Paper : Box;
+  // Manage scroll and focus
+  const answerInputRef = useRef(null);
+
+  useEffect(() => {
+    if (scrollRef?.current && answerInputRef.current) {
+      const { top } = answerInputRef.current.getBoundingClientRect();
+      const containerTop = scrollRef.current.getBoundingClientRect().top;
+
+      scrollRef.current.scrollTop += top - containerTop;
+    }
+  }, [value, scrollRef]);
 
   if (withImages) {
     return (
@@ -109,6 +120,7 @@ export function ListInputRender({
           <Box noFlex={useExplanation}>
             <Box style={{ width: useExplanation ? 250 : '100%' }}>
               <TextInput
+                ref={answerInputRef}
                 label={t('caption')}
                 value={store.imageDescription}
                 onChange={onChangeImageDescription}
@@ -144,6 +156,7 @@ export function ListInputRender({
     <ContextContainer>
       <Box>
         <TextInput
+          ref={answerInputRef}
           value={store.response}
           label={`${t('responseLabel')} *`}
           onChange={onChangeResponse}
@@ -182,4 +195,5 @@ ListInputRender.propTypes = {
   addItem: PropTypes.func,
   value: PropTypes.any,
   onCancel: PropTypes.func,
+  scrollRef: PropTypes.object,
 };

--- a/plugins/leemons-plugin-tests/frontend/src/pages/private/questions-banks/components/question-types/MonoResponse/index.js
+++ b/plugins/leemons-plugin-tests/frontend/src/pages/private/questions-banks/components/question-types/MonoResponse/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { find, findIndex, forEach, capitalize } from 'lodash';
 import {
@@ -18,7 +18,7 @@ import { ListInputRender } from './components/ListInputRender';
 import { ListItemRender } from './components/ListItemRender';
 
 // eslint-disable-next-line import/prefer-default-export
-export function MonoResponse({ form: _form, t }) {
+export function MonoResponse({ form: _form, t, scrollRef }) {
   const form = useFormContext() ?? _form;
   const withImages = form.watch('withImages');
   const properties = form.watch('properties');
@@ -45,6 +45,14 @@ export function MonoResponse({ form: _form, t }) {
       form.setValue('properties.responses', data);
     }
   }
+
+  const monoResponseAnwsersMargin = useMemo(() => {
+    if (!properties?.hasClues) {
+      if (withImages) return { marginBottom: 120 };
+      return { marginBottom: 40 };
+    }
+    return {};
+  }, [properties?.hasClues, withImages]);
 
   return (
     <ContextContainer>
@@ -128,7 +136,7 @@ export function MonoResponse({ form: _form, t }) {
             if (hideOnHelp) canSetHelp = false;
           });
           return (
-            <Box>
+            <Box sx={monoResponseAnwsersMargin}>
               <ListInput
                 {...field}
                 onChange={(e) => {
@@ -145,6 +153,7 @@ export function MonoResponse({ form: _form, t }) {
                     useExplanation={properties?.explanationInResponses}
                     withImages={withImages}
                     onCancel={() => setShowInput(false)}
+                    scrollRef={scrollRef}
                   />
                 }
                 listRender={
@@ -191,4 +200,5 @@ export function MonoResponse({ form: _form, t }) {
 MonoResponse.propTypes = {
   form: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
+  scrollRef: PropTypes.object,
 };


### PR DESCRIPTION
 + add margin to the box that renders the ListInputRender for the add answer button to always be visible, even when the answers contain images.