### PR TITLE
fix(assignables): add unique index to grades schema

### DIFF
--- a/plugins/leemons-plugin-assignables/backend/models/grades.js
+++ b/plugins/leemons-plugin-assignables/backend/models/grades.js
@@ -50,6 +50,8 @@ const gradesSchema = new mongoose.Schema(
   }
 );
 
+gradesSchema.index({ deploymentID: 1, assignation: 1, subject: 1, type: 1 }, { unique: true });
+
 const gradesModel = newModel(mongoose.connection, 'v1::assignables_Grades', gradesSchema);
 
 module.exports = { gradesSchema, gradesModel };


### PR DESCRIPTION
The unique index will avoid grade duplication problems where multiple requests were overlapiing.

Ticket: issue/Transversal-87
