### PR TITLE
feat(deployment-manager): enhance deploymentID retrieval logic

### DIFF
--- a/packages/leemons-deployment-manager/src/getDeploymentID.js
+++ b/packages/leemons-deployment-manager/src/getDeploymentID.js
@@ -5,10 +5,17 @@ async function getDeploymentID(ctx) {
   try {
     ctx.meta.deploymentID = getDeploymentIDFromCTX(ctx);
   } catch (e) {
-    // Si llega un error es que no se encontrado ningun deploymentID, comprobamos la ultima opcion (el dominio)
-    ctx.meta.deploymentID = await ctx.__leemonsDeploymentManagerCall(
-      'deployment-manager.getDeploymentIDByDomain'
-    );
+    const { params } = ctx;
+
+    if (params?.req?.query?.deploymentID) {
+      ctx.meta.deploymentID = params.req.query.deploymentID;
+    } else {
+      // Si llega un error es que no se encontrado ningun deploymentID, comprobamos la ultima opcion (el dominio)
+      ctx.meta.deploymentID = await ctx.__leemonsDeploymentManagerCall(
+        'deployment-manager.getDeploymentIDByDomain'
+      );
+    }
+
     if (!ctx.meta.deploymentID) {
       throw new LeemonsError(ctx, { message: `No deploymentID found [${ctx.meta.hostname}]` });
     }

--- a/plugins/leemons-plugin-assignables/backend/core/instances/sendEmail/sendEmail.js
+++ b/plugins/leemons-plugin-assignables/backend/core/instances/sendEmail/sendEmail.js
@@ -1,5 +1,35 @@
 const { diffHours } = require('@leemons/utils');
 const { isString } = require('lodash');
+
+async function getCoverAndAvatarUrls({ ctx, instance, userSession, hostname, hostnameApi }) {
+  const { deploymentID } = ctx.meta;
+
+  let avatarUrl = userSession?.avatar;
+  let coverUrl = await ctx.tx.call('leebrary.assets.getCoverUrl', {
+    assetId: instance.assignable.asset.id,
+  });
+
+  if (isString(avatarUrl)) {
+    if (!avatarUrl.startsWith('http')) {
+      avatarUrl = `${hostnameApi || hostname}${avatarUrl}`;
+    }
+    const avatarUrlObj = new URL(avatarUrl);
+    avatarUrlObj.searchParams.append('deploymentID', deploymentID);
+    avatarUrl = avatarUrlObj.toString();
+  }
+
+  if (isString(coverUrl)) {
+    if (!coverUrl.startsWith('http')) {
+      coverUrl = `${hostnameApi || hostname}${coverUrl}`;
+    }
+    const coverUrlObj = new URL(coverUrl);
+    coverUrlObj.searchParams.append('deploymentID', deploymentID);
+    coverUrl = coverUrlObj.toString();
+  }
+
+  return { avatarUrl, coverUrl };
+}
+
 /**
  * Sends an email with the instance details.
  *
@@ -70,17 +100,13 @@ async function sendEmail({
         classColor = classes[0].color;
       }
 
-      let avatarUrl = userSession?.avatar;
-      if (isString(avatarUrl) && !avatarUrl.startsWith('http')) {
-        avatarUrl = `${hostnameApi || hostname}${avatarUrl}`;
-      }
-
-      let coverUrl = await ctx.tx.call('leebrary.assets.getCoverUrl', {
-        assetId: instance.assignable.asset.id,
+      const { avatarUrl, coverUrl } = await getCoverAndAvatarUrls({
+        ctx,
+        instance,
+        userSession,
+        hostname,
+        hostnameApi,
       });
-      if (isString(coverUrl) && !coverUrl.startsWith('http')) {
-        coverUrl = `${hostnameApi || hostname}${coverUrl}`;
-      }
 
       const context = {
         instance: {


### PR DESCRIPTION
- Implement query parameter check for deploymentID before falling back to domain-based retrieval.
- Refactor `sendEmail` function in "leemons-plugin-assignables" to use `getCoverAndAvatarUrls` for URL generation, improving code reuse and maintainability.