### PR TITLE
Test - mapa - Marker disabled

### DIFF
--- a/plugins/leemons-plugin-tests/frontend/src/components/QuestionImage.js
+++ b/plugins/leemons-plugin-tests/frontend/src/components/QuestionImage.js
@@ -38,6 +38,7 @@ export function QuestionImage({ src, markers, values, clue }) {
             if (values) {
               backgroundColor = index === values[index] ? COLORS.fatic02 : COLORS.fatic01;
             }
+            const opacity = markers.canShowHintMarker && marker.hideOnHelp ? 0.5 : 1;
 
             return (
               <Box
@@ -47,6 +48,7 @@ export function QuestionImage({ src, markers, values, clue }) {
                   top: marker.top,
                   left: marker.left,
                   backgroundColor,
+                  opacity,
                 }}
               >
                 {markers.type === 'letter' ? numberToEncodedLetter(index + 1) : index + 1}


### PR DESCRIPTION
fix(QuestionImage): If user uses clue on map, the marker got opacity at 0.5