### PR TITLE
fix(leebrary): bring back normal recents behavior + differenciate cover assets from regular ones by the way the are created

### DIFF
--- a/plugins/leemons-plugin-leebrary/backend/core/search/byCriteria/byCriteria.js
+++ b/plugins/leemons-plugin-leebrary/backend/core/search/byCriteria/byCriteria.js
@@ -52,6 +52,7 @@ async function byCriteria({
   programs: _programs,
   subjects: _subjects,
   categoriesFilter,
+  hideCoverAssets,
   ctx,
 }) {
   const published = _published;
@@ -102,6 +103,7 @@ async function byCriteria({
       providerQuery,
       published,
       searchInProvider,
+      hideCoverAssets,
       ctx,
     }));
 

--- a/plugins/leemons-plugin-leebrary/backend/core/search/byCriteria/getProviderAssets.js
+++ b/plugins/leemons-plugin-leebrary/backend/core/search/byCriteria/getProviderAssets.js
@@ -47,6 +47,7 @@ async function getProviderAssets({
   providerQuery,
   published,
   searchInProvider,
+  hideCoverAssets,
   ctx,
 }) {
   let providerAssets = null;
@@ -95,6 +96,10 @@ async function getProviderAssets({
   // A specific category overrides the multi-category filter
   if (categoryId) {
     query.category = categoryId;
+  }
+
+  if (hideCoverAssets) {
+    query.isCover = false;
   }
 
   const [assetsFound, byTags] = await Promise.all([

--- a/plugins/leemons-plugin-leebrary/backend/core/search/byCriteria/getProviderAssets.js
+++ b/plugins/leemons-plugin-leebrary/backend/core/search/byCriteria/getProviderAssets.js
@@ -35,6 +35,44 @@ const { byProvider: getByProvider } = require('../byProvider');
  * @returns {Promise<Object>} - Returns an object containing the retrieved assets and a flag indicating if no assets were found.
  */
 
+function buildQueryObject({
+  indexable,
+  criteria,
+  assetIds,
+  pinned,
+  categoriesFilter,
+  categoryId,
+  hideCoverAssets,
+}) {
+  const query = {
+    indexable,
+  };
+  if (criteria) {
+    query.$or = [
+      { name: { $regex: escapeRegExp(criteria), $options: 'i' } },
+      { tagline: { $regex: escapeRegExp(criteria), $options: 'i' } },
+      { description: { $regex: escapeRegExp(criteria), $options: 'i' } },
+    ];
+  }
+
+  if (!isEmpty(assetIds) || pinned) {
+    query.id = assetIds;
+  }
+
+  if (categoriesFilter?.length) {
+    query.category = categoriesFilter;
+  }
+  // A specific category overrides the multi-category filter
+  if (categoryId) {
+    query.category = categoryId;
+  }
+
+  if (hideCoverAssets) {
+    query.isCover = false;
+  }
+  return query;
+}
+
 async function getProviderAssets({
   assets: _assets,
   categoryId,
@@ -72,35 +110,17 @@ async function getProviderAssets({
   if (providerAssets?.length === 0) {
     return { assets, nothingFound };
   }
-
-  const query = {
-    indexable,
-  };
-
-  if (criteria) {
-    query.$or = [
-      { name: { $regex: escapeRegExp(criteria), $options: 'i' } },
-      { tagline: { $regex: escapeRegExp(criteria), $options: 'i' } },
-      { description: { $regex: escapeRegExp(criteria), $options: 'i' } },
-    ];
-  }
-
   const assetIds = providerAssets || assets;
-  if (!isEmpty(assetIds) || pinned) {
-    query.id = assetIds;
-  }
 
-  if (categoriesFilter?.length) {
-    query.category = categoriesFilter;
-  }
-  // A specific category overrides the multi-category filter
-  if (categoryId) {
-    query.category = categoryId;
-  }
-
-  if (hideCoverAssets) {
-    query.isCover = false;
-  }
+  const query = buildQueryObject({
+    indexable,
+    criteria,
+    assetIds,
+    pinned,
+    categoriesFilter,
+    categoryId,
+    hideCoverAssets,
+  });
 
   const [assetsFound, byTags] = await Promise.all([
     ctx.tx.db.Assets.find(query).select(['id']).lean(),

--- a/plugins/leemons-plugin-leebrary/backend/models/assets.js
+++ b/plugins/leemons-plugin-leebrary/backend/models/assets.js
@@ -51,6 +51,10 @@ const assetsSchema = new mongoose.Schema(
       type: Boolean,
       default: true,
     },
+    isCover: {
+      type: Boolean,
+      default: false,
+    },
     center: {
       type: String,
     },

--- a/plugins/leemons-plugin-leebrary/backend/services/rest/assets.rest.js
+++ b/plugins/leemons-plugin-leebrary/backend/services/rest/assets.rest.js
@@ -167,6 +167,7 @@ module.exports = {
         onlyShared,
         categoryFilter,
         categoriesFilter,
+        hideCoverAssets,
       } = ctx.params;
 
       const trueValues = ['true', true, '1', 1];
@@ -177,6 +178,7 @@ module.exports = {
       const displayPublic = trueValues.includes(showPublic);
       const searchProvider = trueValues.includes(searchInProvider);
       const preferCurrentValue = trueValues.includes(preferCurrent);
+      const _hideCoverAssets = trueValues.includes(hideCoverAssets);
       const _onlyShared = trueValues.includes(onlyShared);
       const parsedRoles = JSON.parse(roles || null) || [];
       const _providerQuery = JSON.parse(providerQuery || null);
@@ -205,6 +207,7 @@ module.exports = {
           sortBy: 'updated_at',
           sortDirection: 'desc',
           categoriesFilter: _categoriesFilter,
+          hideCoverAssets: _hideCoverAssets,
           ctx,
         });
       } else {

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetForm/AssetForm.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetForm/AssetForm.js
@@ -407,6 +407,7 @@ const AssetForm = ({
                   labels={labels}
                   value={coverFile?.id ? coverFile?.id : coverFile}
                   onChange={handleOnSelectAsset}
+                  isPickingACover
                 />
               )}
               <Controller

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetList.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetList.js
@@ -16,7 +16,6 @@ import {
   PaginatedList,
   Drawer,
 } from '@bubbles-ui/components';
-import { useIsStudent } from '@academic-portfolio/hooks';
 import useTranslateLoader from '@multilanguage/useTranslateLoader';
 import { useSession } from '@users/session';
 import { useLayout } from '@layout/context';
@@ -154,7 +153,6 @@ const AssetList = ({
   const [pageAssetsData, setPageAssetsData] = useState(null);
   const [selectedAsset, setSelectedAsset] = useState(null);
   const [cardDetailIsLoading, setCardDetailIsLoading] = useState(false);
-  const isStudent = useIsStudent();
 
   const detailLabels = useMemo(() => {
     if (!isEmpty(translations)) {
@@ -175,23 +173,6 @@ const AssetList = ({
 
   const { newAsset } = useContext(LibraryContext);
   const history = useHistory();
-
-  // For not student users, a default filter is applied in the recent view in order to only show activity assets
-  // If this behavior is not needed anymore, remove this extra filters and don't make any distinction between users
-  const resolveRecentSectionDefaultFilter = useCallback(() => {
-    let resolvedCategoriesFilter;
-    if (categoryFilter === 'all' && !isStudent) {
-      const contentAssignables = ['assignables.scorm', 'assignables.content-creator'];
-      const activityAssetsFilter = categories
-        ?.filter(
-          (item) => item.key?.startsWith('assignables') && !contentAssignables.includes(item.key)
-        )
-        .map((item) => item.id);
-      resolvedCategoriesFilter = JSON.stringify(activityAssetsFilter);
-    }
-
-    return resolvedCategoriesFilter || null;
-  }, [isStudent, categories, categoryFilter]);
 
   // -------------------------------------------------------------------------------------
   // QUERY HOOKS
@@ -225,11 +206,10 @@ const AssetList = ({
     }
     if (category?.key === RECENT_CATEGORY) {
       query.roles = JSON.stringify(['owner']);
+      query.hideCoverAssets = true;
       delete query.category;
       if (categoryFilter !== 'all') {
         query.categoryFilter = find(categories, { key: categoryFilter })?.id;
-      } else {
-        query.categoriesFilter = resolveRecentSectionDefaultFilter(query);
       }
     }
     if (category?.key === PINS_CATEGORY) {

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetPickerDrawer/AssetPickerDrawer.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetPickerDrawer/AssetPickerDrawer.js
@@ -77,6 +77,7 @@ export function AssetPickerDrawer({
   onlyCreateImages,
   acceptedFileTypes,
   onlyImages,
+  isPickingACover,
 }) {
   const localizations = useAssetPickerDrawerLocalizations();
   const { classes } = useAssetPickerDrawerStyles({}, { name: 'AssetPickerDrawer' });
@@ -111,6 +112,7 @@ export function AssetPickerDrawer({
                 onSelect={onSelect}
                 onlyCreateImages={onlyCreateImages}
                 acceptedFileTypes={acceptedFileTypes}
+                isPickingACover={isPickingACover}
               />
             </TabPanel>
           </Tabs>
@@ -149,4 +151,5 @@ AssetPickerDrawer.propTypes = {
   onlyCreateImages: PropTypes.bool,
   onlyImages: PropTypes.bool,
   acceptedFileTypes: PropTypes.arrayOf(PropTypes.string),
+  isPickingACover: PropTypes.bool,
 };

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetPickerDrawer/components/NewResource.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetPickerDrawer/components/NewResource.js
@@ -24,7 +24,12 @@ export const useNewResourceStyles = createStyles((theme) => {
   };
 });
 
-export function NewResource({ categories: creatableCategories, acceptedFileTypes, onSelect }) {
+export function NewResource({
+  categories: creatableCategories,
+  acceptedFileTypes,
+  onSelect,
+  isPickingACover,
+}) {
   const [, translations] = useTranslateLoader(prefixPN('assetSetup'));
   const categories = usePickerCategories();
   const categoriesByKey = useMemo(() => keyBy(categories, 'key'), [categories]);
@@ -73,7 +78,7 @@ export function NewResource({ categories: creatableCategories, acceptedFileTypes
       setUploadingFileInfo({ state: 'finalize' });
       try {
         const { asset } = await newAssetRequest(
-          { ...body, file: uploadedFile },
+          { ...body, file: uploadedFile, isCover: !!isPickingACover },
           null,
           'media-files'
         );
@@ -117,6 +122,7 @@ NewResource.propTypes = {
   onSelect: PropTypes.func,
   categories: PropTypes.arrayOf(PropTypes.string),
   acceptedFileTypes: PropTypes.arrayOf(PropTypes.string),
+  isPickingACover: PropTypes.bool,
 };
 
 NewResource.defaultProps = {

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/ImagePicker.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/ImagePicker.js
@@ -123,6 +123,7 @@ ImagePicker.defaultProps = {
   creatable: true,
   modal: false,
   returnAsset: false,
+  isPickingACover: false,
 };
 ImagePicker.propTypes = {
   labels: PropTypes.shape({
@@ -139,6 +140,7 @@ ImagePicker.propTypes = {
   creatable: PropTypes.bool,
   modal: PropTypes.bool,
   returnAsset: PropTypes.bool,
+  isPickingACover: PropTypes.bool,
 };
 
 export { ImagePicker };

--- a/plugins/leemons-plugin-leebrary/frontend/src/pages/private/assets/ListAssetPage.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/pages/private/assets/ListAssetPage.js
@@ -187,18 +187,7 @@ const ListAssetPage = () => {
 
     // CATEGORY FILTER (not implemented in 'Shared with me' section yet)
     if (isMultiCategorySection && category?.key !== 'leebrary-shared') {
-      if (!isStudent && category?.key === 'leebrary-recent') {
-        // We show only activities in the 'Recent' section when the user is not a student
-        // If this behavior is not needed anymore simply pass true
-        const activityCategories = categories
-          ?.filter(
-            (item) => item.key?.startsWith('assignables') && !contentAssignables.includes(item.key)
-          )
-          .map((item) => item.key);
-        props.allowCategoryFilter = activityCategories;
-      } else {
-        props.allowCategoryFilter = true;
-      }
+      props.allowCategoryFilter = true;
       props.categoryFilter = categoryFilter;
       props.onCategoryFilter = handleCategoryFilterChange;
     }


### PR DESCRIPTION
- Bring back normal recents behavior.
- Store isCover property in asset creation in order to differentiate assets created as covers and be able to filter them from the recents section of the library