### PR TITLE
feat: enhance navigation with useEffect in Setup page

### DIFF
--- a/plugins/leemons-plugin-admin/frontend/src/pages/private/Setup/index.js
+++ b/plugins/leemons-plugin-admin/frontend/src/pages/private/Setup/index.js
@@ -32,12 +32,15 @@ function Setup({ session }) {
   const [t, translations] = useTranslateLoader(prefixPN('setup'));
   const deploymentConfig = useDeploymentConfig({ pluginName: 'users', ignoreVersion: true });
   const history = useHistory();
-  if (
-    deploymentConfig?.superRedirectUrl &&
-    deploymentConfig.superRedirectUrl !== '/private/admin/setup'
-  ) {
-    history.push(deploymentConfig?.superRedirectUrl);
-  }
+
+  React.useEffect(() => {
+    if (
+      deploymentConfig?.superRedirectUrl &&
+      deploymentConfig.superRedirectUrl !== '/private/admin/setup'
+    ) {
+      history.push(deploymentConfig?.superRedirectUrl);
+    }
+  }, [JSON.stringify(deploymentConfig), history]);
 
   // ····················································
   // SETTINGS

--- a/plugins/leemons-plugin-deployment-manager/frontend/src/hooks/useDeploymentConfig.js
+++ b/plugins/leemons-plugin-deployment-manager/frontend/src/hooks/useDeploymentConfig.js
@@ -8,6 +8,8 @@ function useDeploymentConfig({ pluginName, ignoreVersion, ...options }) {
       plugin: 'plugin.deployment-manager',
       scope: 'deploymentConfig',
       action: 'get',
+      pluginName,
+      ignoreVersion,
     },
   ];
 


### PR DESCRIPTION
- Wrap navigation logic inside useEffect to handle redirects based on deploymentConfig changes in `leemons-plugin-admin` Setup page.
- Update `useDeploymentConfig` hook to include `pluginName` and `ignoreVersion` parameters for more precise deployment configurations.
- Update subproject reference to include latest changes.