### PR TITLE
Resources - Creation - Card Vista previa ajustes

### DIFF
--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetForm/AssetForm.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetForm/AssetForm.js
@@ -193,6 +193,10 @@ const AssetForm = ({
     if (isImageType) {
       setValue('cover', assetFile);
     }
+    if (type === LIBRARY_FORM_TYPES.MEDIA_FILES && !assetFile?.path) {
+      setValue('name', null);
+      setValue('cover', null);
+    }
   }, [assetFile]);
 
   useEffect(() => {
@@ -312,6 +316,7 @@ const AssetForm = ({
                         icon={<DownloadIcon height={32} width={32} />}
                         title={labels.browseFile}
                         subtitle={labels.dropFile}
+                        labels={labels}
                         errorMessage={{
                           title: 'Error',
                           message: errorMessages.file?.rejected || 'File was rejected',
@@ -325,7 +330,6 @@ const AssetForm = ({
                     )}
                   />
                 )}
-
                 {type === LIBRARY_FORM_TYPES.BOOKMARKS && (
                   <Controller
                     control={control}
@@ -363,7 +367,6 @@ const AssetForm = ({
                     )}
                   />
                 )}
-
                 {type === 'assignables.scorm' && (
                   <>
                     <Controller

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/CardWrapper.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/CardWrapper.js
@@ -22,9 +22,9 @@ function dynamicImport(pluginName, component) {
   );
 }
 
-const CardWrapperStyles = createStyles((theme, { selected }) => ({
+const CardWrapperStyles = createStyles((theme, { selected, isCreationPreview }) => ({
   root: {
-    cursor: 'pointer',
+    cursor: isCreationPreview ? 'default' : 'pointer',
     borderColor: selected && theme.other.core.color.primary['400'],
     borderWidth: selected && '1px',
     boxShadow: selected && theme.shadows.shadow03,
@@ -60,7 +60,7 @@ const CardWrapper = ({
   const asset = !isEmpty(item?.original) ? prepareAsset(item.original) : {};
   const [t] = useTranslateLoader(prefixPN('list'));
   const history = useHistory();
-  const { classes } = CardWrapperStyles({ selected });
+  const { classes } = CardWrapperStyles({ selected, isCreationPreview });
   const isTeacher = useIsTeacher();
 
   const menuItems = React.useMemo(() => {


### PR DESCRIPTION
fix(test): 
- If delete image preview, card preview image remove too.
- card preview cursor fixed.
- If delete the image asset, preview card return to skeleton (as first render). 
- Fix spanish translations of "Remove" button to "Borrar"