### PR TITLE
Assets - Creation - Falta Label de imagen destacada en presentación 

### DIFF
--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetForm/AssetForm.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetForm/AssetForm.js
@@ -399,7 +399,7 @@ const AssetForm = ({
                 )}
               </ContextContainer>
             )}
-            <ContextContainer title={labels.presentation}>
+            <ContextContainer title={labels.presentation} subtitle={labels.featuredImage}>
               {!isImage && !hideCover && (
                 <ImagePicker
                   labels={labels}


### PR DESCRIPTION
fix(leebrary): add subtitle to "Presentation" section on AssetForm.