### PR TITLE
fix(academic-portfolio): handle missing data on `EnrollUserSummary`

### DIFF
--- a/plugins/leemons-plugin-academic-portfolio/frontend/src/components/EnrollUserSummary/EnrollUserSummary.js
+++ b/plugins/leemons-plugin-academic-portfolio/frontend/src/components/EnrollUserSummary/EnrollUserSummary.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { isString, uniq } from 'lodash';
+import { compact, isString, uniq } from 'lodash';
 import {
   Box,
   Tabs,
@@ -28,19 +28,24 @@ function filterUserAgentIds(userAgents, sysProfileFilter) {
 
 function getTeacherFullname(teacherId, teachers) {
   const item = teachers.find((teacher) => teacher.id === teacherId);
-  return `${item?.user?.surnames}, ${item?.user?.name}`;
+  const parts = compact([item?.user?.surnames, item?.user?.name]);
+
+  if (parts.length > 1) {
+    return parts.join(', ');
+  }
+
+  return parts.length === 1 ? parts[0] : '';
 }
 
 function getTeachersIds(enrollments = []) {
-  return uniq(
-    enrollments.flatMap((enrollment) =>
-      enrollment.subjects?.flatMap((subject) =>
-        subject.classes?.flatMap((classroom) =>
-          classroom.teachers?.map((teacher) => teacher.teacher)
-        )
+  const teacherIds = enrollments.flatMap((enrollment) =>
+    (enrollment.subjects ?? []).flatMap((subject) =>
+      (subject.classes ?? []).flatMap((classroom) =>
+        (classroom.teachers ?? []).map((teacher) => teacher?.teacher)
       )
     )
   );
+  return compact(uniq(teacherIds));
 }
 
 function EnrollUserSummary({ userId, center, contactUserAgentId, sysProfileFilter, viewMode }) {
@@ -110,7 +115,7 @@ function EnrollUserSummary({ userId, center, contactUserAgentId, sysProfileFilte
                   <Box>
                     {!isStudent && (
                       <Text>
-                        {getTeacherFullname(subject.classes[0].teachers[0].teacher, teachers)}
+                        {getTeacherFullname(subject.classes[0]?.teachers[0]?.teacher, teachers)}
                       </Text>
                     )}
                   </Box>

--- a/plugins/leemons-plugin-academic-portfolio/frontend/src/components/EnrollUserSummary/components/SubjectWithClassroomDisplay.js
+++ b/plugins/leemons-plugin-academic-portfolio/frontend/src/components/EnrollUserSummary/components/SubjectWithClassroomDisplay.js
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
-import { AvatarSubject, Box, Text, Stack } from '@bubbles-ui/components';
+import { compact, noop } from 'lodash';
+import { AvatarSubject, Text, Stack } from '@bubbles-ui/components';
 import { getFileUrl } from '@leebrary/helpers/prepareAsset';
 import useTranslateLoader from '@multilanguage/useTranslateLoader';
 import prefixPN from '@academic-portfolio/helpers/prefixPN';
@@ -19,14 +19,14 @@ function getIconUrl(subject, classroom) {
 }
 
 function getClassroomName(classroom, course, t = noop) {
-  const parts = [course?.name];
+  const parts = [(course?.name ?? '').replace('undefined 1', '').trim()];
   const groupTranslation = t('subjects.group') ?? 'Group';
   if (classroom?.groups?.length) {
-    parts.push(`${groupTranslation} ${classroom.groups[0]}`);
+    parts.push(groupTranslation, classroom.groups[0]);
   } else if (classroom?.classWithoutGroupId) {
-    parts.push(`${groupTranslation} ${classroom.classWithoutGroupId}`);
+    parts.push(groupTranslation, classroom.classWithoutGroupId);
   }
-  return parts.join(' ');
+  return compact(parts).join(' ');
 }
 
 function SubjectWithClassroomDisplay({ subject, course, classroom }) {
@@ -39,7 +39,7 @@ function SubjectWithClassroomDisplay({ subject, course, classroom }) {
         icon={getIconUrl(subject, classroom)}
       />
       <Text strong color="primary">
-        {subject.name}
+        {subject.name ?? ''}
       </Text>
       <Text>{getClassroomName(classroom, course, t)}</Text>
     </Stack>


### PR DESCRIPTION
- Use lodash's `compact` to remove falsy values from arrays
- Safely access nested properties using optional chaining
- Trim and clean up course names
- Join name parts more robustly in `getTeacherFullname`
- Make `getTeachersIds` more defensive by handling missing data