### PR TITLE
fix(academic-portfolio): Allow user to preserve not saved changes when modifying the subject and enrolling students at the same time. 

### DIFF
--- a/plugins/leemons-plugin-academic-portfolio/frontend/src/hooks/keys/classStudents.js
+++ b/plugins/leemons-plugin-academic-portfolio/frontend/src/hooks/keys/classStudents.js
@@ -1,0 +1,13 @@
+export const allClassStudents = [
+  {
+    plugin: 'plugin.academic-portfolio',
+    scope: 'course-detail',
+  },
+];
+
+export const getClassStudentsKey = (classId) => [
+  {
+    ...allClassStudents[0],
+    classId,
+  },
+];

--- a/plugins/leemons-plugin-academic-portfolio/frontend/src/hooks/mutations/useMutateClass.js
+++ b/plugins/leemons-plugin-academic-portfolio/frontend/src/hooks/mutations/useMutateClass.js
@@ -8,6 +8,7 @@ import {
 } from '@academic-portfolio/request';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { getProgramSubjectsKey } from '../keys/programSubjects';
+import { getClassStudentsKey } from '../keys/classStudents';
 
 export function useUpdateClass() {
   const queryClient = useQueryClient();
@@ -51,7 +52,8 @@ export function useEnrollStudentsToClasses() {
       classes.forEach((cls) => {
         const programSubjectsKey = getProgramSubjectsKey(cls.program);
         queryClient.invalidateQueries(programSubjectsKey);
-        queryClient.invalidateQueries(['subjectDetail', { subject: cls.subject.id }]);
+        const classStudentsKey = getClassStudentsKey(cls.id);
+        queryClient.invalidateQueries(classStudentsKey);
       });
     },
   });

--- a/plugins/leemons-plugin-academic-portfolio/frontend/src/hooks/queries/useClassStudents.js
+++ b/plugins/leemons-plugin-academic-portfolio/frontend/src/hooks/queries/useClassStudents.js
@@ -1,0 +1,26 @@
+import { classByIdsRequest } from '@academic-portfolio/request';
+import { useVariantForQueryKey } from '@common/queries';
+import { useQuery } from '@tanstack/react-query';
+import { getClassStudentsKey } from '../keys/classStudents';
+
+// TODO: Implement function to only get students from a class in backend, this is a temporary solution as changes in backend must be avoided right now
+export default function useClassStudents({ classId, options }) {
+  const queryKey = getClassStudentsKey(classId);
+
+  const queryFn = async () => {
+    const response = await classByIdsRequest(classId);
+    const data = response.classes[0];
+    return data?.students ?? [];
+  };
+
+  useVariantForQueryKey(queryKey, {
+    modificationTrend: 'frequently',
+  });
+
+  return useQuery({
+    ...options,
+    refetchOnWindowFocus: false,
+    queryKey,
+    queryFn,
+  });
+}


### PR DESCRIPTION
Implement useClassStudents hook to be able to manage states separately for the user not to lose not saved changes when filling the EnrollmentTab form (in AcaTree) and enrolling students at the same time.

- This is a temporary fix as backend changes are "forbiden" temporarly. Once we can make changes in backend a new rest action should be created to bring only the desired data. 