### PR TITLE
Kanban-Drawer falta titular de subtareas

### DIFF
--- a/plugins/leemons-plugin-calendar/frontend/src/widgets/calendar/task.js
+++ b/plugins/leemons-plugin-calendar/frontend/src/widgets/calendar/task.js
@@ -235,6 +235,10 @@ export default function Task({ event, form, classes, disabled, allProps }) {
         ) : null}
         {!disabled || (disabled && subtask && subtask.length) ? (
           <ContextContainer spacing={4}>
+            <Text size="lg" strong>
+              {subtask?.length === 1 ? t('subtask') : t('subtaskLabel')}
+            </Text>
+
             <Controller
               name="subtask"
               control={control}


### PR DESCRIPTION
fix(calendar): on Event detail drawer of Kanban, show "subtask" header on subtasks section.