### PR TITLE
Academic Portfolio groups minor issues

### DIFF
--- a/plugins/leemons-plugin-academic-portfolio/backend/core/groups/getGroupById.js
+++ b/plugins/leemons-plugin-academic-portfolio/backend/core/groups/getGroupById.js
@@ -5,11 +5,19 @@ async function getGroupById({ id, ctx }) {
     type: 'course',
   }).lean();
   const manager = await ctx.tx.db.Managers.findOne({ relationship: id }).lean();
+  if (group.metadata) {
+    return {
+      ...group,
+      manager: manager?.userAgent ?? null,
+      parentCourseSeats: programCourses.find((crs) => crs.index === group.metadata.course)?.metadata
+        .seats,
+    };
+  }
+  // This handles the case of programs with non-sequential courses. Where a metadata object is not needed. All courses have the same number of seats.
   return {
     ...group,
     manager: manager?.userAgent ?? null,
-    parentCourseSeats: programCourses.find((crs) => crs.index === group.metadata.course)?.metadata
-      .seats,
+    parentCourseSeats: programCourses[0].metadata.seats,
   };
 }
 

--- a/plugins/leemons-plugin-academic-portfolio/backend/core/programs/getAcademicTree.js
+++ b/plugins/leemons-plugin-academic-portfolio/backend/core/programs/getAcademicTree.js
@@ -24,7 +24,7 @@ function handleNonSequentialAndSingleCourses({ groups, knowledgeAreas, subjects,
             type: 'subject',
           })),
       }))
-      .sort((a, b) => a.abbreviation - b.abbreviation);
+      .sort((a, b) => a.abbreviation.localeCompare(b.abbreviation));
 
     // Subjects with no group are shown at root level
     const groupedSubjectIds = tree.flatMap((group) => group.children.map((subject) => subject.id));


### PR DESCRIPTION
It changes only academic-portfolio plugin.
- Groups retrieval in cases where a program with non-sequential courses has reference groups 
- Compare strings with localCompare when ordering groups for the AcademicTree