### PR TITLE
Main Library - Faltan estados “activos” de cards en algunas tipologías

### DIFF
--- a/plugins/leemons-plugin-content-creator/frontend/src/widgets/leebrary/DocumentListCard.js
+++ b/plugins/leemons-plugin-content-creator/frontend/src/widgets/leebrary/DocumentListCard.js
@@ -20,7 +20,7 @@ import { useIsStudent } from '@academic-portfolio/hooks';
 const DocumentCardStyles = createStyles((theme, { selected }) => ({
   root: {
     cursor: 'pointer',
-    borderColor: selected && theme.colors.interactive01d,
+    borderColor: selected && theme.other.core.color.primary['400'],
     borderWidth: selected && '1px',
     boxShadow: selected && theme.shadows.shadow03,
   },

--- a/plugins/leemons-plugin-feedback/frontend/src/widgets/leebrary/FeedbackListCard.js
+++ b/plugins/leemons-plugin-feedback/frontend/src/widgets/leebrary/FeedbackListCard.js
@@ -18,7 +18,7 @@ import { FeedbackCardIcon } from '../../components/FeedbackCardIcon';
 const ListCardStyles = createStyles((theme, { selected }) => ({
   root: {
     cursor: 'pointer',
-    borderColor: selected && theme.colors.interactive01d,
+    borderColor: selected && theme.other.core.color.primary['400'],
     borderWidth: selected && '1px',
     boxShadow: selected && theme.shadows.shadow03,
   },

--- a/plugins/leemons-plugin-learning-paths/frontend/src/widgets/leebrary/ListCard.js
+++ b/plugins/leemons-plugin-learning-paths/frontend/src/widgets/leebrary/ListCard.js
@@ -148,9 +148,12 @@ function useListCardMenuItems({ asset, localizations, onRefresh }) {
   );
 }
 
-const useListCardStyles = createStyles((theme, { single }) => ({
+const useListCardStyles = createStyles((theme, { single, selected }) => ({
   root: {
     cursor: single ? 'default' : 'pointer',
+    borderColor: selected && theme.other.core.color.primary['400'],
+    borderWidth: selected && '1px',
+    boxShadow: selected && theme.shadows.shadow03,
   },
 }));
 

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetPlayer/AssetPlayer.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetPlayer/AssetPlayer.js
@@ -374,12 +374,14 @@ const AssetPlayer = ({
                   >
                     {showPlayButton && (
                       <Box className={classes.buttonIcon}>
-                        <ButtonIcon
-                          fileType={'video'}
-                          onClick={(e) => {
-                            if (ccMode && !canPlay) handleInitPlay();
-                          }}
-                        />
+                        {isPlaying ? null : (
+                          <ButtonIcon
+                            fileType={'video'}
+                            onClick={(e) => {
+                              if (ccMode && !canPlay) handleInitPlay();
+                            }}
+                          />
+                        )}
                       </Box>
                     )}
                     {cover ? (

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/CardWrapper.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/CardWrapper.js
@@ -169,6 +169,7 @@ const CardWrapper = ({
         isLoading={assetsLoading}
         onPin={onPin}
         onUnpin={onUnpin}
+        selected={selected}
       />
     </Box>
   ) : null;

--- a/plugins/leemons-plugin-tasks/frontend/src/widgets/leebrary/ListCard.js
+++ b/plugins/leemons-plugin-tasks/frontend/src/widgets/leebrary/ListCard.js
@@ -17,9 +17,12 @@ import { ExpressTaskIcon } from '../../components/Icons/ExpressTaskIcon';
 import { TaskIcon } from '../../components/Icons/TaskIcon';
 import { prefixPN } from '../../helpers/prefixPN';
 
-const ListCardStyles = createStyles((theme, { single }) => ({
+const ListCardStyles = createStyles((theme, { single, selected }) => ({
   root: {
     cursor: single ? 'default' : 'pointer',
+    borderColor: selected && theme.other.core.color.primary['400'],
+    borderWidth: selected && '1px',
+    boxShadow: selected && theme.shadows.shadow03,
   },
 }));
 
@@ -197,6 +200,7 @@ const ListCard = ({
       // TRANSLATE
       variantTitle={isExpress ? expressTaskLabel : taskLabel}
       className={classes.root}
+      selected={selected}
     />
   );
 };

--- a/plugins/leemons-plugin-tests/frontend/src/widgets/leebrary/QuestionsBanksListCard.js
+++ b/plugins/leemons-plugin-tests/frontend/src/widgets/leebrary/QuestionsBanksListCard.js
@@ -16,7 +16,7 @@ import { QuestionBankIcon } from '../../components/Icons/QuestionBankIcon';
 const ListCardStyles = createStyles((theme, { selected }) => ({
   root: {
     cursor: 'pointer',
-    borderColor: selected && theme.colors.interactive01d,
+    borderColor: selected && theme.other.core.color.primary['400'],
     borderWidth: selected && '1px',
     boxShadow: selected && theme.shadows.shadow03,
   },

--- a/plugins/leemons-plugin-tests/frontend/src/widgets/leebrary/TestsListCard.js
+++ b/plugins/leemons-plugin-tests/frontend/src/widgets/leebrary/TestsListCard.js
@@ -20,7 +20,7 @@ import { deleteTestRequest, duplicateRequest } from '../../request';
 const ListCardStyles = createStyles((theme, { selected }) => ({
   root: {
     cursor: 'pointer',
-    borderColor: selected && theme.colors.interactive01d,
+    borderColor: selected && theme.other.core.color.primary['400'],
     borderWidth: selected && '1px',
     boxShadow: selected && theme.shadows.shadow03,
   },


### PR DESCRIPTION
Add "active" color border to this asset cards:
- C.Creator
- Tasks
- Tests
- QBank
- Surveys
- Modules
In audio resources, remove centered play button if audio is playing. 