### PR TITLE
feat(LocaleDate): add LocaleWeekDay function to format weekdays

### DIFF
--- a/plugins/leemons-plugin-common/frontend/src/LocaleDate.js
+++ b/plugins/leemons-plugin-common/frontend/src/LocaleDate.js
@@ -125,3 +125,25 @@ export function LocaleDuration({ seconds: secondsProp, short = false, options = 
   const session = useSession();
   return getLocaleDuration({ seconds: secondsProp, short, options }, session);
 }
+
+export function LocaleWeekDay({ day }) {
+  const session = useSession();
+
+  if (!day) {
+    return '';
+  }
+
+  const locale = getLocale(session);
+  const key = getFormatterKey(locale, { weekday: 'long' });
+
+  if (!formatters[key]) {
+    formatters[key] = new Intl.DateTimeFormat([locale, 'default'], { weekday: 'long' });
+  }
+  // Create an arbitrary date that is a Monday
+  // Leemons use Sunday as the first day of the week (day 0)
+  const referenceDate = new Date(Date.UTC(2021, 0, 4)); // January 4 2021 is a Monday
+  // Adjust the date to the desired day of the week
+  const targetDate = new Date(referenceDate);
+  targetDate.setUTCDate(referenceDate.getUTCDate() + day - 1);
+  return formatters[key].format(targetDate);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14394,6 +14394,11 @@ loader-utils@^2.0.0, loader-utils@^2.0.4:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
+localized-countries@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/localized-countries/-/localized-countries-2.0.0.tgz#bd7a25622969afb9d03291ef09f7902efdde01fc"
+  integrity sha512-17CwJ/oetI5cB6KmPa+Cxw/8vunawUouVv5MFxYqsVzryXeR5u/MF32m3SBaHxP4EqYPOePV+3jx7xxYZnAJpQ==
+
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"


### PR DESCRIPTION
Add LocaleWeekDay function to format weekdays based on locale

- Introduced `LocaleWeekDay` function to format and return the name of the weekday based on the user's locale.
- Utilizes `Intl.DateTimeFormat` for locale-specific formatting.
- Adjusts the reference date to match the desired day of the week.