### PR TITLE
feat(widgets): hide widgets based on deployment configuration

### DIFF
--- a/plugins/leemons-plugin-widgets/backend/core/widgetZone/get.js
+++ b/plugins/leemons-plugin-widgets/backend/core/widgetZone/get.js
@@ -2,12 +2,25 @@ const _ = require('lodash');
 
 async function get({ key, ctx }) {
   const { userSession } = ctx.meta;
-  const [zone, items] = await Promise.all([
+
+  const [zone, items, deploymentConfig] = await Promise.all([
     ctx.tx.db.WidgetZone.findOne({ key }).lean(),
     ctx.tx.db.WidgetItem.find({ zoneKey: key }).lean(),
+    ctx.tx.call('deployment-manager.getConfigRest'),
   ]);
 
-  let widgetItems = _.orderBy(items, ['order'], ['asc']);
+  const zonesDenied = _.get(deploymentConfig, 'deny.zone', []);
+
+  if (_.includes(zonesDenied, zone.key)) {
+    return zone;
+  }
+
+  const itemsDenied = _.get(deploymentConfig, 'deny.item', []);
+  const itemsAllowed = items.filter(
+    (item) => !_.includes(itemsDenied, item.key) && !_.includes(zonesDenied, item.zoneKey)
+  );
+
+  let widgetItems = _.orderBy(itemsAllowed, ['order'], ['asc']);
 
   if (userSession) {
     const [userAgents, itemProfiles] = await Promise.all([

--- a/plugins/leemons-plugin-widgets/backend/services/widgets.service.js
+++ b/plugins/leemons-plugin-widgets/backend/services/widgets.service.js
@@ -4,7 +4,7 @@
  */
 
 const { LeemonsCacheMixin } = require('@leemons/cache');
-const { LeemonsMongoDBMixin, mongoose } = require('@leemons/mongodb');
+const { LeemonsMongoDBMixin } = require('@leemons/mongodb');
 const { LeemonsDeploymentManagerMixin } = require('@leemons/deployment-manager');
 const { LeemonsMiddlewaresMixin } = require('@leemons/middlewares');
 
@@ -99,8 +99,5 @@ module.exports = {
         return itemServices.updateProfiles({ ...ctx.params, ctx });
       },
     },
-  },
-  async created() {
-    // mongoose.connect(process.env.MONGO_URI);
   },
 };


### PR DESCRIPTION
- Added call to `deployment-manager.getConfigRest` to fetch deployment configuration.
- Filtered out denied zones and items based on the deployment configuration.
- Ordered allowed widget items by their `order` property.
- Removed unnecessary MongoDB connection in `widgets.service.js`.