### PR TITLE
fix(leebrary): stop uploading `zip`s as `directories` by default

### DIFF
--- a/plugins/leemons-plugin-leebrary/frontend/src/helpers/uploadFileAsMultipart.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/helpers/uploadFileAsMultipart.js
@@ -179,11 +179,10 @@ async function getZipFiles(jsfile) {
 
 async function uploadFileAsMultipart(
   jsfile,
-  { onProgress = () => {}, name } = {},
-  isScormFolder = false
+  { onProgress = () => {}, name, isFolder: _isFolder = false } = {}
 ) {
   if (jsfile instanceof File || jsfile instanceof Blob) {
-    const isFolder = isScormFolder && jsfile.name?.endsWith('.zip');
+    const isFolder = _isFolder && jsfile.name?.endsWith('.zip');
     const filePaths = [];
     const pathsInfo = {};
 

--- a/plugins/leemons-plugin-leebrary/frontend/src/helpers/uploadFileAsMultipart.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/helpers/uploadFileAsMultipart.js
@@ -177,9 +177,13 @@ async function getZipFiles(jsfile) {
   return Promise.all(_.map(entries, downloadEntry));
 }
 
-async function uploadFileAsMultipart(jsfile, { onProgress = () => {}, name } = {}) {
+async function uploadFileAsMultipart(
+  jsfile,
+  { onProgress = () => {}, name } = {},
+  isScormFolder = false
+) {
   if (jsfile instanceof File || jsfile instanceof Blob) {
-    const isFolder = jsfile.name?.endsWith('.zip');
+    const isFolder = isScormFolder && jsfile.name?.endsWith('.zip');
     const filePaths = [];
     const pathsInfo = {};
 

--- a/plugins/leemons-plugin-scorm/frontend/src/pages/Detail/index.js
+++ b/plugins/leemons-plugin-scorm/frontend/src/pages/Detail/index.js
@@ -81,6 +81,7 @@ export default function Detail() {
       onProgress: (info) => {
         setUploadingFileInfo(info);
       },
+      isScormFolder: true,
     });
     setUploadingFileInfo(null);
 

--- a/plugins/leemons-plugin-scorm/frontend/src/pages/Detail/index.js
+++ b/plugins/leemons-plugin-scorm/frontend/src/pages/Detail/index.js
@@ -77,15 +77,12 @@ export default function Detail() {
   const savePackage = async ({ publishing = true, assigning }) => {
     setIsLoading(true);
 
-    const file = await uploadFileAsMultipart(
-      formValues.file,
-      {
-        onProgress: (info) => {
-          setUploadingFileInfo(info);
-        },
+    const file = await uploadFileAsMultipart(formValues.file, {
+      onProgress: (info) => {
+        setUploadingFileInfo(info);
       },
-      true
-    );
+      isFolder: true,
+    });
     setUploadingFileInfo(null);
 
     const requestBody = {

--- a/plugins/leemons-plugin-scorm/frontend/src/pages/Detail/index.js
+++ b/plugins/leemons-plugin-scorm/frontend/src/pages/Detail/index.js
@@ -77,12 +77,15 @@ export default function Detail() {
   const savePackage = async ({ publishing = true, assigning }) => {
     setIsLoading(true);
 
-    const file = await uploadFileAsMultipart(formValues.file, {
-      onProgress: (info) => {
-        setUploadingFileInfo(info);
+    const file = await uploadFileAsMultipart(
+      formValues.file,
+      {
+        onProgress: (info) => {
+          setUploadingFileInfo(info);
+        },
       },
-      isScormFolder: true,
-    });
+      true
+    );
     setUploadingFileInfo(null);
 
     const requestBody = {


### PR DESCRIPTION
 - Adds a parameter to the uploadFileAsMultlipart to specify when a zip file should be understood as a folder.
 - It defaults to false and it is only passed as true in the savePackage function of the Scorm plugin.

**NOTE:** If SCORM creation is intended to occur only on the SCORM creation page, this fix should suffice. However, if SCORM creation (uploading a zip as a folder) is required elsewhere in the application, such as in the asset drawer, it must be specifically implemented there.