### PR TITLE
feat(leebrary): Allow asset sharing on every asset type

### DIFF
--- a/plugins/leemons-plugin-feedback/backend/i18n/en.js
+++ b/plugins/leemons-plugin-feedback/backend/i18n/en.js
@@ -111,6 +111,7 @@ module.exports = {
     open: 'Open',
     duplicate: 'Duplicate',
     duplicated: 'Duplicated',
+    share: 'Share',
     pin: 'Mark as favorite',
     unpin: 'Unmark as favorite',
   },

--- a/plugins/leemons-plugin-feedback/backend/i18n/es.js
+++ b/plugins/leemons-plugin-feedback/backend/i18n/es.js
@@ -111,6 +111,7 @@ module.exports = {
     open: 'Abrir',
     duplicate: 'Duplicar',
     duplicated: 'Duplicado',
+    share: 'Compartir',
     pin: 'Marcar como favorito',
     unpin: 'Quitar de favorito',
   },

--- a/plugins/leemons-plugin-feedback/frontend/src/widgets/leebrary/FeedbackDetail.js
+++ b/plugins/leemons-plugin-feedback/frontend/src/widgets/leebrary/FeedbackDetail.js
@@ -11,7 +11,7 @@ import { ViewOnIcon } from '@bubbles-ui/icons/outline';
 import { deleteFeedbackRequest, duplicateFeedbackRequest } from '@feedback/request';
 import { AssetMetadataFeedback } from '../../components/AssetMetadataFeedback';
 
-const FeedbackDetail = ({ asset, onRefresh, onPin, onUnpin, ...props }) => {
+const FeedbackDetail = ({ asset, onRefresh, onPin, onUnpin, onShare, ...props }) => {
   const history = useHistory();
   const [t] = useTranslateLoader(prefixPN('feedbackCard'));
   const {
@@ -45,6 +45,9 @@ const FeedbackDetail = ({ asset, onRefresh, onPin, onUnpin, ...props }) => {
       if (asset.pinned === true) {
         toolbarItems.unpin = t('unpin');
       }
+    }
+    if (asset.shareable) {
+      toolbarItems.share = t('share');
     }
   }
 
@@ -95,6 +98,10 @@ const FeedbackDetail = ({ asset, onRefresh, onPin, onUnpin, ...props }) => {
     })();
   };
 
+  const handleOnShare = () => {
+    onShare(asset);
+  };
+
   const handleAssign = () => {
     history.push(`/private/feedback/assign/${asset.providerData.id}`);
   };
@@ -129,9 +136,9 @@ const FeedbackDetail = ({ asset, onRefresh, onPin, onUnpin, ...props }) => {
       titleActionButton={
         asset?.providerData?.published
           ? {
-            icon: <ViewOnIcon height={16} width={16} />,
-            onClick: handleView,
-          }
+              icon: <ViewOnIcon height={16} width={16} />,
+              onClick: handleView,
+            }
           : null
       }
       onEdit={handleEdit}
@@ -140,6 +147,7 @@ const FeedbackDetail = ({ asset, onRefresh, onPin, onUnpin, ...props }) => {
       onDelete={handleDelete}
       onAssign={handleAssign}
       onDuplicate={handleDuplicate}
+      onShare={handleOnShare}
     />
   );
 };
@@ -149,6 +157,7 @@ FeedbackDetail.propTypes = {
   onRefresh: PropTypes.func,
   onPin: PropTypes.func,
   onUnpin: PropTypes.func,
+  onShare: PropTypes.func,
 };
 
 export default FeedbackDetail;

--- a/plugins/leemons-plugin-feedback/frontend/src/widgets/leebrary/FeedbackListCard.js
+++ b/plugins/leemons-plugin-feedback/frontend/src/widgets/leebrary/FeedbackListCard.js
@@ -13,6 +13,7 @@ import { AssignIcon } from '@leebrary/components/LibraryDetailToolbar/icons/Assi
 import { DeleteIcon } from '@leebrary/components/LibraryDetailToolbar/icons/DeleteIcon';
 import { EditIcon } from '@leebrary/components/LibraryDetailToolbar/icons/EditIcon';
 import { DuplicateIcon } from '@leebrary/components/LibraryDetailToolbar/icons/DuplicateIcon';
+import { ShareIcon } from '@leebrary/components/LibraryDetailToolbar/icons/ShareIcon';
 import { FeedbackCardIcon } from '../../components/FeedbackCardIcon';
 
 const ListCardStyles = createStyles((theme, { selected }) => ({
@@ -24,7 +25,7 @@ const ListCardStyles = createStyles((theme, { selected }) => ({
   },
 }));
 
-const FeedbackListCard = ({ asset, selected, onRefresh, ...props }) => {
+const FeedbackListCard = ({ asset, selected, onRefresh, onShare, ...props }) => {
   const [t] = useTranslateLoader(prefixPN('feedbackCard'));
   const { classes } = ListCardStyles({ selected });
   const {
@@ -99,7 +100,7 @@ const FeedbackListCard = ({ asset, selected, onRefresh, ...props }) => {
       if (asset.deleteable) {
         items.push({
           icon: <DeleteIcon />,
-          children: 'Delete',
+          children: t('delete'),
           onClick: (e) => {
             e.stopPropagation();
             openDeleteConfirmationModal({
@@ -115,6 +116,16 @@ const FeedbackListCard = ({ asset, selected, onRefresh, ...props }) => {
                 setAppLoading(false);
               },
             })();
+          },
+        });
+      }
+      if (asset.shareable) {
+        items.push({
+          icon: <ShareIcon />,
+          children: t('share'),
+          onClick: (e) => {
+            e.stopPropagation();
+            onShare(asset);
           },
         });
       }

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetSetup/PermissionsData.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetSetup/PermissionsData.js
@@ -1,5 +1,9 @@
 /* eslint-disable no-param-reassign */
-import { classByIdsRequest, detailProgramRequest } from '@academic-portfolio/request';
+import {
+  classByIdsRequest,
+  detailProgramRequest,
+  getProfilesRequest,
+} from '@academic-portfolio/request';
 import {
   Box,
   Tabs,
@@ -96,6 +100,18 @@ const PermissionsData = ({
   const { classes: classesStyles } = PermissionsDataStyles();
   const [activeTab, setActiveTab] = useState('tab1');
 
+  const [teacherProfile, setTeacherProfile] = useState(null);
+
+  const getTeacherProfile = async () => {
+    const response = await getProfilesRequest();
+    setTeacherProfile(response?.profiles?.teacher);
+  };
+  // EFFECTS
+  // ··············································································
+  useEffect(() => {
+    getTeacherProfile();
+  }, []);
+
   const handleTabChange = (key) => {
     setActiveTab(key);
   };
@@ -140,8 +156,8 @@ const PermissionsData = ({
     const assetPermissions = [];
     const programsNeedCenter = [];
     const classesNeedCenter = [];
-    _.forEach(Object.keys(asset.permissions), (role) => {
-      _.forEach(asset.permissions[role], (permission) => {
+    _.forEach(Object.keys(asset?.permissions), (role) => {
+      _.forEach(asset?.permissions[role], (permission) => {
         const obj = getObjectByPermission(permission);
         if (obj) {
           if (obj.center === null && obj.class) classesNeedCenter.push(obj.class);
@@ -394,7 +410,9 @@ const PermissionsData = ({
       }
     }
     if (profileSysName === 'teacher') {
-      result.push({ label: t('permissionsData.labels.shareTypeClasses'), value: 'classes' });
+      if (!asset.providerData || asset.providerData.role === 'content-creator') {
+        result.push({ label: t('permissionsData.labels.shareTypeClasses'), value: 'classes' });
+      }
       result.push({ label: t('permissionsData.labels.shareTypeUsers'), value: 'users' });
     }
 
@@ -466,7 +484,7 @@ const PermissionsData = ({
       {!isEmpty(asset) && (
         <ContextContainer className={classesStyles.contentContainer}>
           <Text className={classesStyles.titleItem}>{t('permissionsData.header.libraryItem')}</Text>
-          <Paper bordered padding={1} shadow="none" className={classesStyles.libraryItem}>
+          <Paper padding={1} shadow="none" className={classesStyles.libraryItem}>
             <LibraryCardEmbed asset={asset} hideIcon />
           </Paper>
           <Text className={classesStyles.titleTabs}>
@@ -624,6 +642,12 @@ const PermissionsData = ({
                       roles={roles}
                       value={usersData}
                       alreadySelectedUsers={editUsersData}
+                      onlyForTeachers={
+                        asset.providerData &&
+                        asset.providerData.role &&
+                        asset.providerData.role !== 'content-creator'
+                      }
+                      teacherProfile={teacherProfile}
                       onChange={setUsersData}
                       asset={asset}
                       t={t}

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/AssetSetup/components/PermissionsDataUsers.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/AssetSetup/components/PermissionsDataUsers.js
@@ -1,22 +1,15 @@
-import {
-  Box,
-  ContextContainer,
-  Paragraph,
-  Select,
-  TableInput,
-  Table,
-  Title,
-  UserDisplayItem,
-} from '@bubbles-ui/components';
+import { ContextContainer, Select, TableInput, UserDisplayItem } from '@bubbles-ui/components';
 import SelectUserAgent from '@users/components/SelectUserAgent';
 import _, { find, isEmpty, isNil } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { useMemo } from 'react';
 
-const SelectAgents = ({ usersData, ...props }) => (
+const SelectAgents = ({ usersData, onlyForTeachers, teacherProfile, ...props }) => (
   <SelectUserAgent
     {...props}
     onlyContacts={true}
+    profiles={teacherProfile}
+    onlyForTeachers={onlyForTeachers}
     selectedUsers={_.map(usersData, 'user.id')}
     returnItem
   />
@@ -24,6 +17,8 @@ const SelectAgents = ({ usersData, ...props }) => (
 
 SelectAgents.propTypes = {
   usersData: PropTypes.array,
+  onlyForTeachers: PropTypes.bool,
+  teacherProfile: PropTypes.object,
 };
 
 const RoleSelect = (props) => {
@@ -39,13 +34,18 @@ RoleSelect.propTypes = {
   onChange: PropTypes.func,
 };
 
-const PermissionsDataUsers = ({ editMode, roles, value, onChange, alreadySelectedUsers, t }) => {
-  // ··············································································
-  // EFFECTS
-
+const PermissionsDataUsers = ({
+  editMode,
+  roles,
+  value,
+  onChange,
+  alreadySelectedUsers,
+  t,
+  onlyForTeachers,
+  teacherProfile,
+}) => {
   // ··············································································
   // HANDLERS
-
   const checkIfUserIsAdded = (userData) => {
     const found = find(value, (data) => data.user.id === userData.user.id);
     return isNil(found);
@@ -53,14 +53,19 @@ const PermissionsDataUsers = ({ editMode, roles, value, onChange, alreadySelecte
 
   // ··············································································
   // LABELS & STATICS
-
   const USERS_COLUMNS = useMemo(
     () => [
       {
         Header: 'User',
         accessor: 'user',
         input: {
-          node: <SelectAgents usersData={[...alreadySelectedUsers, ...value]} />,
+          node: (
+            <SelectAgents
+              onlyForTeachers={onlyForTeachers}
+              teacherProfile={teacherProfile}
+              usersData={[...alreadySelectedUsers, ...value]}
+            />
+          ),
           rules: { required: 'Required field' },
         },
         editable: false,
@@ -128,6 +133,8 @@ PermissionsDataUsers.propTypes = {
   translations: PropTypes.object,
   editMode: PropTypes.bool,
   alreadySelectedUsers: PropTypes.any,
+  onlyForTeachers: PropTypes.bool,
+  teacherProfile: PropTypes.string,
 };
 
 export default PermissionsDataUsers;

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/LibraryDetailContent/LibraryDetailContent.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/LibraryDetailContent/LibraryDetailContent.js
@@ -137,14 +137,7 @@ const LibraryDetailContent = ({
                   {canAccessData.map((user, index) => (
                     <Box key={index} className={classes.canAccessItem}>
                       <Box className={classes.avatarWrapper}>
-                        <UserDisplayItem
-                          variant="inline"
-                          size="md"
-                          alt={user?.name}
-                          name={user?.name}
-                          surnames={user?.surnames}
-                          image={user.avatar}
-                        />
+                        <UserDisplayItem variant="inline" size="md" {...user} />
                       </Box>
                       <Box className={classes.canAccessTextContainer}>
                         <Text className={classes.canAccessText}>

--- a/plugins/leemons-plugin-tasks/frontend/src/widgets/leebrary/Detail.js
+++ b/plugins/leemons-plugin-tasks/frontend/src/widgets/leebrary/Detail.js
@@ -71,9 +71,9 @@ const Detail = ({ asset, onRefresh, onShare, ...props }) => {
     history.push(`/private/tasks/library/view/${asset.providerData.id}`);
   };
 
-  // const handleOnShare = () => {
-  //   onShare(asset);
-  // };
+  const handleOnShare = () => {
+    onShare(asset);
+  };
 
   const handleEdit = () => {
     history.push(`/private/tasks/library/edit/${asset.providerData.id}`);
@@ -145,7 +145,7 @@ const Detail = ({ asset, onRefresh, onShare, ...props }) => {
       onEdit={handleEdit}
       onDuplicate={handleDuplicate}
       onAssign={handleAssign}
-      // onShare={handleOnShare}
+      onShare={handleOnShare}
     />
   );
 };

--- a/plugins/leemons-plugin-tests/frontend/src/widgets/leebrary/QuestionsBanksDetail.js
+++ b/plugins/leemons-plugin-tests/frontend/src/widgets/leebrary/QuestionsBanksDetail.js
@@ -11,7 +11,7 @@ import useRequestErrorMessage from '@common/useRequestErrorMessage';
 import { useLayout } from '@layout/context';
 import { AssetMetadataQuestionBank } from '@tests/components/AssetMetadataQuestionBank';
 
-const QuestionsBanksDetail = ({ asset, onRefresh, ...props }) => {
+const QuestionsBanksDetail = ({ asset, onRefresh, onShare, ...props }) => {
   const [t] = useTranslateLoader(prefixPN('testsCard'));
   const { openConfirmationModal, openDeleteConfirmationModal } = useLayout();
   const [, , , getErrorMessage] = useRequestErrorMessage();
@@ -31,6 +31,9 @@ const QuestionsBanksDetail = ({ asset, onRefresh, ...props }) => {
     }
     if (asset.pinned === true) {
       toolbarItems.unpin = t('unpin');
+    }
+    if (asset.shareable) {
+      toolbarItems.share = t('share');
     }
   }
 
@@ -87,6 +90,7 @@ const QuestionsBanksDetail = ({ asset, onRefresh, ...props }) => {
       toolbarItems={toolbarItems}
       onEdit={handleEdit}
       onDelete={handleDelete}
+      onShare={onShare}
     />
   );
 };
@@ -94,6 +98,7 @@ const QuestionsBanksDetail = ({ asset, onRefresh, ...props }) => {
 QuestionsBanksDetail.propTypes = {
   asset: PropTypes.any,
   onRefresh: PropTypes.func,
+  onShare: PropTypes.func,
 };
 
 export default QuestionsBanksDetail;

--- a/plugins/leemons-plugin-tests/frontend/src/widgets/leebrary/QuestionsBanksListCard.js
+++ b/plugins/leemons-plugin-tests/frontend/src/widgets/leebrary/QuestionsBanksListCard.js
@@ -11,6 +11,8 @@ import useRequestErrorMessage from '@common/useRequestErrorMessage';
 import { useLayout } from '@layout/context';
 import { DeleteIcon } from '@leebrary/components/LibraryDetailToolbar/icons/DeleteIcon';
 import { EditIcon } from '@leebrary/components/LibraryDetailToolbar/icons/EditIcon';
+import { ShareIcon } from '@leebrary/components/LibraryDetailToolbar/icons/ShareIcon';
+
 import { QuestionBankIcon } from '../../components/Icons/QuestionBankIcon';
 
 const ListCardStyles = createStyles((theme, { selected }) => ({
@@ -22,7 +24,7 @@ const ListCardStyles = createStyles((theme, { selected }) => ({
   },
 }));
 
-const QuestionsBanksListCard = ({ asset, selected, onRefresh, ...props }) => {
+const QuestionsBanksListCard = ({ asset, selected, onRefresh, onShare, ...props }) => {
   const [t] = useTranslateLoader(prefixPN('testsCard'));
   const { classes } = ListCardStyles({ selected });
   const { openDeleteConfirmationModal } = useLayout();
@@ -64,6 +66,13 @@ const QuestionsBanksListCard = ({ asset, selected, onRefresh, ...props }) => {
           },
         });
       }
+      if (asset.shareable) {
+        items.push({
+          icon: <ShareIcon />,
+          children: t('share'),
+          onClick: onShare,
+        });
+      }
     }
 
     return items;
@@ -87,6 +96,7 @@ QuestionsBanksListCard.propTypes = {
   variant: PropTypes.string,
   selected: PropTypes.bool,
   onRefresh: PropTypes.func,
+  onShare: PropTypes.func,
 };
 
 export default QuestionsBanksListCard;

--- a/plugins/leemons-plugin-users/frontend/src/components/SelectUserAgent.js
+++ b/plugins/leemons-plugin-users/frontend/src/components/SelectUserAgent.js
@@ -55,6 +55,7 @@ const SelectUserAgent = forwardRef(
       value: inputValue = [],
       onChange = () => {},
       clearable = true,
+      onlyForTeachers = false,
       ...props
     },
     ref
@@ -77,7 +78,7 @@ const SelectUserAgent = forwardRef(
             email: value,
           },
         };
-        if (profiles) {
+        if (profiles && onlyForTeachers) {
           filters.profile = profiles;
         }
 
@@ -222,6 +223,8 @@ const SelectUserAgent = forwardRef(
               withProfile: true,
             });
 
+            console.log('data', data);
+
             data = data.userAgents.map((item) => ({
               ...item.user,
               variant: 'rol',
@@ -335,6 +338,7 @@ SelectUserAgent.propTypes = {
   selectedUsers: PropTypes.any,
   selectedUserAgents: PropTypes.any,
   clearable: PropTypes.bool,
+  onlyForTeachers: PropTypes.bool,
 };
 
 SelectUserAgentValueComponent.propTypes = {

--- a/plugins/leemons-plugin-users/frontend/src/components/SelectUserAgent.js
+++ b/plugins/leemons-plugin-users/frontend/src/components/SelectUserAgent.js
@@ -223,7 +223,6 @@ const SelectUserAgent = forwardRef(
               withProfile: true,
             });
 
-            console.log('data', data);
 
             data = data.userAgents.map((item) => ({
               ...item.user,


### PR DESCRIPTION
Some assets can't share with students (only between teachers). 
Remove double border on asset in Permission Drawer (Libary embed card must have only one border)
Permissions tab on Detail drawer must show user image (if exist).