### PR TITLE
feat(bulk-data): enhance bulk data import with caching and progress tracking

### DIFF
--- a/apps/dev/moleculer.config.js
+++ b/apps/dev/moleculer.config.js
@@ -71,7 +71,7 @@ module.exports = {
   serializer: 'JSON',
 
   // Number of milliseconds to wait before reject a request with a RequestTimeout error. Disabled: 0
-  requestTimeout: 2 * 60 * 1000,
+  requestTimeout: 10 * 60 * 1000, // 2 * 60 * 1000,
 
   // Retry policy settings. More info: https://moleculer.services/docs/0.14/fault-tolerance.html#Retry
   retryPolicy: {

--- a/plugins/leemons-plugin-bulk-data/backend/core/importHandlers/loadTemplateFromUrl.js
+++ b/plugins/leemons-plugin-bulk-data/backend/core/importHandlers/loadTemplateFromUrl.js
@@ -66,6 +66,7 @@ async function loadFromTemplateURL({
   templateURL,
   shareLibraryAssetsWithTeacherProfile,
   shouldInitializeForClientManager = true,
+  onFinishData = {},
   ctx,
 }) {
   if (!templateURL) {
@@ -92,21 +93,15 @@ async function loadFromTemplateURL({
     preConfig = await initializeForClientManager({ ctx });
   }
 
-  try {
-    await importBulkData({
-      docPath: file.path,
-      preConfig,
-      shareLibraryAssetsWithTeacherProfile,
-      ctx,
-    });
-    return { status: 200 };
-  } catch (error) {
-    console.error('Error importing bulk-data', error);
-    throw new LeemonsError(ctx, {
-      message: `Something went wrong importing from template URL: ${error}`,
-      httpStatusCode: 500,
-    });
-  }
+  importBulkData({
+    docPath: file.path,
+    preConfig,
+    shareLibraryAssetsWithTeacherProfile,
+    onFinishData,
+    ctx,
+  });
+
+  return true;
 }
 
 module.exports = { loadFromTemplateURL };

--- a/plugins/leemons-plugin-bulk-data/backend/core/leebrary.js
+++ b/plugins/leemons-plugin-bulk-data/backend/core/leebrary.js
@@ -2,8 +2,9 @@
 const { keys, isEmpty } = require('lodash');
 const importLibrary = require('./bulk/library');
 const _delay = require('./bulk/helpers/delay');
+const { LOAD_PHASES } = require('./importHandlers/getLoadStatus');
 
-async function initLibrary({ file, config: { users }, ctx }) {
+async function initLibrary({ file, config: { users }, ctx, useCache, phaseKey }) {
   try {
     const assets = await importLibrary(file, { users });
     const assetsKeys = keys(assets);
@@ -27,6 +28,14 @@ async function initLibrary({ file, config: { users }, ctx }) {
           assets[key] = { ...assetData };
 
           ctx.logger.info(`Asset ADDED: ${asset.name}`);
+
+          if (useCache) {
+            await ctx.cache.set(
+              phaseKey,
+              `${LOAD_PHASES.LIBRARY}[${i + 1}/${assetsKeys.length}]`,
+              60 * 60
+            );
+          }
         } catch (e) {
           ctx.logger.log('-- ASSET CREATION ERROR --');
           ctx.logger.error(e);

--- a/plugins/leemons-plugin-bulk-data/backend/core/tasks.js
+++ b/plugins/leemons-plugin-bulk-data/backend/core/tasks.js
@@ -3,8 +3,9 @@ const chalk = require('chalk');
 const { keys } = require('lodash');
 const importTasks = require('./bulk/tasks');
 const _delay = require('./bulk/helpers/delay');
+const { LOAD_PHASES } = require('./importHandlers/getLoadStatus');
 
-async function initTasks({ file, config, ctx }) {
+async function initTasks({ file, config, ctx, useCache, phaseKey }) {
   try {
     const tasks = await importTasks({ filePath: file, config, ctx });
 
@@ -24,6 +25,13 @@ async function initTasks({ file, config, ctx }) {
         tasks[key] = { ...taskData };
 
         ctx.logger.info(chalk`{cyan.bold BULK} Task ADDED: ${task.asset?.name}`);
+        if (useCache) {
+          await ctx.cache.set(
+            phaseKey,
+            `${LOAD_PHASES.TASKS}[${i + 1}/${tasksKeys.length}]`,
+            60 * 60
+          );
+        }
       } catch (e) {
         ctx.logger.log('-- TASK CREATION ERROR --');
         ctx.logger.log(`task: ${task.asset?.name}`);

--- a/plugins/leemons-plugin-bulk-data/backend/core/tests.js
+++ b/plugins/leemons-plugin-bulk-data/backend/core/tests.js
@@ -6,8 +6,9 @@ const importQbanks = require('./bulk/tests/qbanks');
 const importQuestions = require('./bulk/tests/questions');
 const importTests = require('./bulk/tests/tests');
 const _delay = require('./bulk/helpers/delay');
+const { LOAD_PHASES } = require('./importHandlers/getLoadStatus');
 
-async function initTests({ file, config: { users, programs }, ctx }) {
+async function initTests({ file, config: { users, programs }, ctx, useCache, phaseKey }) {
   try {
     // ·····················································
     // QUESTIONS
@@ -107,6 +108,14 @@ async function initTests({ file, config: { users, programs }, ctx }) {
 
         tests[key] = { ...testData };
         ctx.logger.info(chalk`{cyan.bold BULK} Test ADDED: ${test.name}`);
+
+        if (useCache) {
+          await ctx.cache.set(
+            phaseKey,
+            `${LOAD_PHASES.TESTS}[${i + 1}/${testsKeys.length}]`,
+            60 * 60
+          );
+        }
       } catch (e) {
         ctx.logger.log('-- TEST CREATION ERROR --');
         ctx.logger.log(`test: ${test.name}`);

--- a/plugins/leemons-plugin-bulk-data/backend/services/bulk.service.js
+++ b/plugins/leemons-plugin-bulk-data/backend/services/bulk.service.js
@@ -8,6 +8,7 @@ const { LeemonsMongoDBMixin } = require('@leemons/mongodb');
 
 const { pluginName } = require('../config/constants');
 const restActions = require('./rest/bulk.rest');
+const { loadFromTemplateURL } = require('../core/importHandlers');
 
 module.exports = {
   name: `${pluginName}.bulk`,
@@ -23,5 +24,17 @@ module.exports = {
   ],
   actions: {
     ...restActions,
+    loadFromTemplateURL: {
+      async handler(ctx) {
+        const { templateURL, shareLibraryAssetsWithTeacherProfile, onFinishData } = ctx.params;
+        loadFromTemplateURL({
+          templateURL,
+          shareLibraryAssetsWithTeacherProfile,
+          onFinishData,
+          ctx,
+        });
+        return true;
+      },
+    },
   },
 };

--- a/plugins/leemons-plugin-bulk-data/backend/services/rest/bulk.rest.js
+++ b/plugins/leemons-plugin-bulk-data/backend/services/rest/bulk.rest.js
@@ -57,7 +57,7 @@ module.exports = {
       method: 'GET',
     },
     async handler(ctx) {
-      return getLoadStatus({ useCache: true, ctx });
+      return getLoadStatus({ useCache: true, initOnPhase: ctx.params?.initOnPhase, ctx });
     },
   },
   generateBulkDataRest: {

--- a/plugins/leemons-plugin-calendar/backend/services/deploy.service.js
+++ b/plugins/leemons-plugin-calendar/backend/services/deploy.service.js
@@ -141,7 +141,7 @@ module.exports = () => ({
     },
 
     // --- Classes ---
-    'academic-portfolio:after-remove-classes-students': async (ctx) => {
+    'academic-portfolio.after-remove-classes-students': async (ctx) => {
       await onAcademicPortfolioRemoveClassStudents({ ...ctx.params, ctx });
     },
     'academic-portfolio.after-add-class-student': async (ctx) => {


### PR DESCRIPTION
- Added `initOnPhase` parameter to `getLoadProgress` and `getLoadStatus` for phase initialization.
- Updated `importBulkData` to include `onFinishData` and emit `finish-load-template` event.
- Modified `loadFromTemplateURL` to handle `onFinishData` and return true.
- Enhanced `initLibrary`, `initTasks`, and `initTests` to support caching and progress tracking.
- Added `loadFromTemplateURL` action to bulk service.
- Fixed event name in calendar deploy service.