### PR TITLE
feat(calendar): add support for showing hidden columns in calendar views

### DIFF
--- a/plugins/leemons-plugin-assignables/backend/core/instances/createInstance/createEventAndAddToUsers.js
+++ b/plugins/leemons-plugin-assignables/backend/core/instances/createInstance/createEventAndAddToUsers.js
@@ -14,23 +14,13 @@ async function createEventAndAddToUsers({
 }) {
   const { id: event } = await registerEvent({ assignable, classes, id, dates, isAllDay, ctx });
 
-  // EN: Grant users to access event
-  // ES: Da permiso a los usuarios para ver el evento
-  if (event && teachers && teachers.length) {
-    await ctx.tx.call('calendar.calendar.grantAccessUserAgentToEvent', {
-      id: event,
-      userAgentId: map(teachers, 'teacher'),
-      actionName: 'view',
-    });
-  }
-
-  if (students.length) {
-    // EN: Grant users to access event
-    // ES: Da permiso a los usuarios para ver el evento
-    if (event) {
+  // Grant users to access event
+  if (event && (teachers?.length || students?.length)) {
+    const userAgentIds = [...map(teachers, 'teacher'), ...students].filter(Boolean);
+    if (userAgentIds.length) {
       await ctx.tx.call('calendar.calendar.grantAccessUserAgentToEvent', {
         id: event,
-        userAgentId: students,
+        userAgentId: userAgentIds,
         actionName: 'view',
       });
     }

--- a/plugins/leemons-plugin-calendar/backend/core/calendar/getCalendarsToFrontend.js
+++ b/plugins/leemons-plugin-calendar/backend/core/calendar/getCalendarsToFrontend.js
@@ -19,14 +19,18 @@ function hasGrades(studentData) {
 }
 
 /**
- * Add calendar with the provided key if not already exists
+ * Adds a calendar with the provided key if it does not already exist.
+ * This function ensures that duplicate calendars are not created in the system.
+ * It checks for the existence of a calendar with the given key and adds it if absent.
+ *
  * @public
  * @static
- * @param {any} userSession - key
- * @param {any=} transacting - DB Transaction
- * @return {Promise<any>}
- * */
-async function getCalendarsToFrontend({ ctx }) {
+ * @param {Object} params - The parameters for getting calendars to frontend.
+ * @param {boolean} params.showHiddenColumns - Flag to determine if hidden columns should be shown.
+ * @param {Object} params.ctx - The context object containing the database transaction and other relevant data.
+ * @return {Promise<any>} A promise that resolves to the newly added calendar details or an existing calendar if the key is already present.
+ */
+async function getCalendarsToFrontend({ showHiddenColumns, ctx }) {
   const { userSession } = ctx.meta;
   const permissionConfigCalendar = getPermissionConfigCalendar();
   const permissionConfigEvent = getPermissionConfigEvent();
@@ -354,7 +358,7 @@ async function getCalendarsToFrontend({ ctx }) {
       ctx.tx.call('assignables.assignableInstances.getAssignableInstancesStatus', {
         assignableInstanceIds: instanceIds,
       }),
-      listKanbanColumns({ ctx }),
+      listKanbanColumns({ showHiddenColumns, ctx }),
       ctx.tx.call('assignables.assignableInstances.getAssignableInstances', {
         ids: instanceIds,
         details: true,

--- a/plugins/leemons-plugin-calendar/backend/core/kanban-columns/list.js
+++ b/plugins/leemons-plugin-calendar/backend/core/kanban-columns/list.js
@@ -1,15 +1,23 @@
 const _ = require('lodash');
 
 /**
- * List kanban columns
+ * List kanban columns based on visibility settings.
+ * This function retrieves all kanban columns from the database and filters them based on the visibility flag.
+ *
  * @public
  * @static
- * @param {any=} transacting - DB Transaction
- * @return {Promise<any>}
- * */
-async function list({ ctx }) {
+ * @param {Object} options - The options for listing kanban columns.
+ * @param {boolean} options.showHiddenColumns - Flag to determine if hidden columns should be shown.
+ * @param {Object} options.ctx - The context object containing the database transaction and other relevant data.
+ * @return {Promise<Array>} A promise that resolves to an array of kanban column objects.
+ */
+async function list({ showHiddenColumns, ctx }) {
   let columns = await ctx.tx.db.KanbanColumns.find().lean();
-  columns = _.filter(columns, (column) => !column.isHidden);
+
+  if (!showHiddenColumns) {
+    columns = _.filter(columns, (column) => !column.isHidden);
+  }
+
   return _.map(columns, (column) => ({
     ...column,
     nameKey: ctx.prefixPN(`kanban.columns.${column.id}`),

--- a/plugins/leemons-plugin-calendar/frontend/src/components/calendar-event-modal.js
+++ b/plugins/leemons-plugin-calendar/frontend/src/components/calendar-event-modal.js
@@ -133,7 +133,8 @@ function NewCalendarEventModal({
 
   async function getCalendarsForCenter() {
     const { calendars, events, userCalendar, ownerCalendars } = await getCalendarsToFrontendRequest(
-      centerToken
+      centerToken,
+      { showHiddenColumns: true }
     );
 
     return {

--- a/plugins/leemons-plugin-calendar/frontend/src/pages/private/Calendar/index.js
+++ b/plugins/leemons-plugin-calendar/frontend/src/pages/private/Calendar/index.js
@@ -70,7 +70,7 @@ function Calendar({ session }) {
   async function getCalendarsForCenter(center) {
     const [{ calendars, events, userCalendar, ownerCalendars, calendarConfig }, schedule] =
       await Promise.all([
-        getCalendarsToFrontendRequest(center.token),
+        getCalendarsToFrontendRequest(center.token, { showHiddenColumns: true }),
         getScheduleToFrontendRequest(center.token),
       ]);
 

--- a/plugins/leemons-plugin-calendar/frontend/src/request/getCalendarsToFrontend.js
+++ b/plugins/leemons-plugin-calendar/frontend/src/request/getCalendarsToFrontend.js
@@ -1,7 +1,10 @@
-async function getCalendarsToFrontend(centerToken) {
+async function getCalendarsToFrontend(centerToken, { showHiddenColumns } = {}) {
   return leemons.api('v1/calendar/calendar', {
     centerToken,
     method: 'POST',
+    body: {
+      showHiddenColumns,
+    },
   });
 }
 

--- a/plugins/leemons-plugin-calendar/frontend/src/widgets/user-program-calendar/index.js
+++ b/plugins/leemons-plugin-calendar/frontend/src/widgets/user-program-calendar/index.js
@@ -116,7 +116,9 @@ function UserProgramCalendar({
     store.currentLoaded = JSON.stringify({ program, classe });
     store.centers = getCentersWithToken();
     if (store.centers) {
-      const promises = [getCalendarsToFrontendRequest(store.centers[0].token)];
+      const promises = [
+        getCalendarsToFrontendRequest(store.centers[0].token, { showHiddenColumns: true }),
+      ];
       if (program) promises.push(listSessionClassesRequest({ program: program.id }));
       const [centerData, programData] = await Promise.all(promises);
       store.centerData = centerData;


### PR DESCRIPTION
- Updated `getCalendarsToFrontend` to accept `showHiddenColumns` parameter.
- Modified `list` function to filter kanban columns based on `showHiddenColumns` flag.
- Adjusted frontend components and requests to include `showHiddenColumns` parameter.
- Enhanced documentation for better clarity on new parameter usage.