### PR TITLE
fix(tests): disable footer buttons if no question selected in the test

### DIFF
--- a/plugins/leemons-plugin-tests/frontend/src/pages/private/tests/components/DetailQuestions.js
+++ b/plugins/leemons-plugin-tests/frontend/src/pages/private/tests/components/DetailQuestions.js
@@ -183,6 +183,8 @@ export default function DetailQuestions({
     }
   };
 
+  const testHasQuestionsSelected = formValues.questions?.length > 0;
+
   const filteredQuestionsActive = radioSelection === 'filteredQuestions' ? filteredQuestions : null;
   const RandomQuestionsActive = radioSelection === 'randomQuestions' ? randomQuestions : null;
 
@@ -208,7 +210,7 @@ export default function DetailQuestions({
                 <Button
                   variant="link"
                   onClick={handleOnSave}
-                  disabled={!formValues.name}
+                  disabled={!formValues.name || !testHasQuestionsSelected}
                   loading={store.saving === 'draft'}
                 >
                   {t('saveDraft')}
@@ -222,12 +224,13 @@ export default function DetailQuestions({
                   setIsDirty={setIsDirty}
                   onAssign={onAssign}
                   onPublish={onPublish}
+                  disabled={!formValues.name || !testHasQuestionsSelected}
                 />
               ) : (
                 <Button
                   rightIcon={<ChevRightIcon height={20} width={20} />}
                   onClick={onNext}
-                  disabled={store.saving}
+                  disabled={store.saving || !testHasQuestionsSelected}
                   loading={store.saving === 'publish'}
                 >
                   {t(getNextButtonLabel())}

--- a/plugins/leemons-plugin-tests/frontend/src/pages/private/tests/components/FinalDropdown.js
+++ b/plugins/leemons-plugin-tests/frontend/src/pages/private/tests/components/FinalDropdown.js
@@ -10,6 +10,7 @@ export default function FinalDropdown({
   setIsDirty = noop,
   onPublish = noop,
   onAssign = noop,
+  disabled,
 }) {
   // ························································
   // HANDLERS
@@ -38,7 +39,7 @@ export default function FinalDropdown({
         { label: t('publishAndAssign'), onClick: handleOnAssign },
       ]}
       // loading={store.saving === 'publish'}
-      // disabled={store.saving}
+      disabled={disabled}
     >
       {t('finish')}
     </DropdownButton>
@@ -52,4 +53,5 @@ FinalDropdown.propTypes = {
   onAssign: PropTypes.func,
   store: PropTypes.any,
   setIsDirty: PropTypes.func,
+  disabled: PropTypes.bool,
 };


### PR DESCRIPTION
fix(tests): In creation or edit mode, if user don't select any questions, disable footer buttons to prevent a tests without questions