### PR TITLE
feat: Added `Go to dashboard` button on module's sub-activities previews

### DIFF
--- a/plugins/leemons-plugin-content-creator/backend/i18n/en.js
+++ b/plugins/leemons-plugin-content-creator/backend/i18n/en.js
@@ -18,6 +18,7 @@ module.exports = {
     cancelModalDescription: 'Do you want to cancel the document?',
     cancelModalConfirm: 'Confirm',
     cancelModalCancel: 'Back',
+    goBackToDashboardPreview: 'Go back to dashboard',
   },
   documentDetail: {
     basic: 'Basic',

--- a/plugins/leemons-plugin-content-creator/backend/i18n/es.js
+++ b/plugins/leemons-plugin-content-creator/backend/i18n/es.js
@@ -18,6 +18,7 @@ module.exports = {
     cancelModalDescription: '¿Deseas cancelar el documento?',
     cancelModalConfirm: 'Confirmar',
     cancelModalCancel: 'Atrás',
+    goBackToDashboardPreview: 'Volver al dashboard',
   },
   documentDetail: {
     basic: 'Información básica',

--- a/plugins/leemons-plugin-content-creator/frontend/src/pages/Detail/index.js
+++ b/plugins/leemons-plugin-content-creator/frontend/src/pages/Detail/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useHistory, useParams, useLocation } from 'react-router-dom';
+import { useHistory, useParams, useLocation, Link } from 'react-router-dom';
 import { useLayout } from '@layout/context';
 import {
   LoadingOverlay,
@@ -62,6 +62,8 @@ export default function Index({ isNew, readOnly }) {
     resolver: zodResolver(validators[activeStep]),
   });
   const formValues = useWatch({ control: form.control });
+  const isModulePreview = window?.location?.href?.includes('moduleId');
+  const moduleId = window?.location?.href?.split('moduleId=')[1];
 
   // ··································································
   // HANDLERS
@@ -216,7 +218,13 @@ export default function Index({ isNew, readOnly }) {
             compact
             mainActionLabel={t('cancel')}
             cancelable={!readOnly}
+            direction="row"
           >
+            {isModulePreview && (
+              <Link to={`/private/learning-paths/modules/${moduleId}/view`}>
+                <Button variant="outline">{t('goBackToDashboardPreview')}</Button>
+              </Link>
+            )}
             {!readOnly && <div id="toolbar-div" style={{ width: '100%' }} ref={toolbarRef}></div>}
           </TotalLayoutHeader>
         }

--- a/plugins/leemons-plugin-feedback/backend/i18n/en.js
+++ b/plugins/leemons-plugin-feedback/backend/i18n/en.js
@@ -197,6 +197,7 @@ module.exports = {
     actionsHeader: 'Acciones',
     showPreview: 'See preview',
     returnToTable: 'Return to table',
+    goBackToDashboardPreview: 'Go back to dashboard',
   },
   feedbackDrawerDetail: {
     survey: 'Survey',

--- a/plugins/leemons-plugin-feedback/backend/i18n/es.js
+++ b/plugins/leemons-plugin-feedback/backend/i18n/es.js
@@ -197,6 +197,7 @@ module.exports = {
     actionsHeader: 'Acciones',
     showPreview: 'Ver vista previa',
     returnToTable: 'Volver a la tabla',
+    goBackToDashboardPreview: 'Volver al dashboard',
   },
   feedbackDrawerDetail: {
     survey: 'Encuesta',

--- a/plugins/leemons-plugin-feedback/frontend/src/pages/private/feedback/Preview/index.js
+++ b/plugins/leemons-plugin-feedback/frontend/src/pages/private/feedback/Preview/index.js
@@ -90,12 +90,15 @@ export default function Preview() {
       accessor: 'type',
       className: classes.tableHeader,
     },
-    {
+  ];
+
+  if (!isModulePreview) {
+    tableHeaders.push({
       Header: tD('actionsHeader'),
       accessor: 'actions',
       className: classes.tableHeader,
-    },
-  ];
+    });
+  }
 
   // function getStats() {
   //   const selectables = [];

--- a/plugins/leemons-plugin-feedback/frontend/src/pages/private/feedback/Preview/index.js
+++ b/plugins/leemons-plugin-feedback/frontend/src/pages/private/feedback/Preview/index.js
@@ -22,14 +22,14 @@ import useTranslateLoader from '@multilanguage/useTranslateLoader';
 import prefixPN from '@feedback/helpers/prefixPN';
 import { getQuestionForTable } from '@feedback/helpers/getQuestionForTable';
 import { useStore } from '@common';
-import { useHistory, useParams } from 'react-router-dom';
+import { useHistory, useParams, Link } from 'react-router-dom';
 import { addErrorAlert } from '@layout/alert';
 import { ChevronRightIcon, EditIcon } from '@bubbles-ui/icons/outline';
 import { getFeedbackRequest } from '@feedback/request';
 import { map } from 'lodash';
 import QuestionsCard from '@feedback/pages/private/feedback/StudentInstance/components/QuestionsCard';
 
-const PreviewPageStyles = createStyles((theme, { viewMode }) => ({
+const PreviewPageStyles = createStyles((theme) => ({
   firstTableHeader: {
     paddingLeft: `${theme.spacing[6]}px !important`,
   },
@@ -63,6 +63,8 @@ export default function Preview() {
   const [tD, t2V] = useTranslateLoader(prefixPN('feedbackDetail'));
   const { classes, cx } = PreviewPageStyles({}, { name: 'FeedbackPreview' });
   const scrollRef = useRef();
+  const isModulePreview = window?.location?.href?.includes('moduleId');
+  const moduleId = window?.location?.href?.split('moduleId=')[1];
 
   const [store, render] = useStore({
     loading: true,
@@ -214,14 +216,20 @@ export default function Preview() {
           icon={<AssetFeedbackIcon />}
           direction="row"
         >
-          <Box style={{ display: 'flex', gap: 16 }}>
-            <Button variant="outline" onClick={() => goEditPage()}>
-              {tP('edit')}
-            </Button>
-            <Button variant="primary" onClick={() => goAssignPage()}>
-              {tP('assign')}
-            </Button>
-          </Box>
+          {isModulePreview ? (
+            <Link to={`/private/learning-paths/modules/${moduleId}/view`}>
+              <Button variant="outline">{tP('goBackToDashboardPreview')}</Button>
+            </Link>
+          ) : (
+            <Box style={{ display: 'flex', gap: 16 }}>
+              <Button variant="outline" onClick={() => goEditPage()}>
+                {tP('edit')}
+              </Button>
+              <Button variant="primary" onClick={() => goAssignPage()}>
+                {tP('assign')}
+              </Button>
+            </Box>
+          )}
         </TotalLayoutHeader>
       }
     >

--- a/plugins/leemons-plugin-learning-paths/frontend/src/components/ModuleDashboard/components/DashboardCard/components/DashboardCardFooter/DashboardCardFooter.js
+++ b/plugins/leemons-plugin-learning-paths/frontend/src/components/ModuleDashboard/components/DashboardCard/components/DashboardCardFooter/DashboardCardFooter.js
@@ -52,7 +52,11 @@ export function useStudentState({ assignation = {} }) {
 function PreviewActions({ activity, localizations }) {
   const { id, roleDetails } = activity?.assignable ?? {};
   const { classes } = useDashboardCardFooterStyles();
-  const url = roleDetails.previewUrl?.replace(':id', id);
+  const currentUrl = window.location.href;
+  const moduleIdMatch = currentUrl.match(/modules\/(.*?)\/view/);
+  const moduleId = moduleIdMatch ? moduleIdMatch[1] : '';
+  const url =
+    roleDetails.previewUrl && `${roleDetails.previewUrl?.replace(':id', id)}?moduleId=${moduleId}`;
   if (!url) {
     return null;
   }

--- a/plugins/leemons-plugin-tasks/backend/i18n/en.js
+++ b/plugins/leemons-plugin-tasks/backend/i18n/en.js
@@ -423,6 +423,7 @@ module.exports = {
       save: 'Save',
       nextActivity: 'Next activity',
       goToModule: 'Module dashboard',
+      goBackToDashboardPreview: 'Go back to dashboard',
     },
     submission_step: {
       instructions: 'Instructions',

--- a/plugins/leemons-plugin-tasks/backend/i18n/es.js
+++ b/plugins/leemons-plugin-tasks/backend/i18n/es.js
@@ -414,6 +414,7 @@ module.exports = {
       save: 'Guardar',
       nextActivity: 'Siguiente actividad',
       goToModule: 'Dashboard del módulo',
+      goBackToDashboardPreview: 'Volver al dashboard',
     },
     submission_step: {
       instructions: 'Instrucciones',

--- a/plugins/leemons-plugin-tasks/frontend/src/components/Student/TaskDetail/TaskDetail.js
+++ b/plugins/leemons-plugin-tasks/frontend/src/components/Student/TaskDetail/TaskDetail.js
@@ -14,6 +14,7 @@ import { getMultiClassData } from '@assignables/helpers/getClassData';
 import ActivityHeader from '@assignables/components/ActivityHeader';
 import { useHistory } from 'react-router-dom';
 import useUserAgents from '@users/hooks/useUserAgents';
+import PropTypes from 'prop-types';
 import StepContainer from './components/StepContainer/StepContainer';
 
 function useTaskDetailLocalizations() {
@@ -166,3 +167,9 @@ export default function TaskDetail({ id, student, preview }) {
     </TotalLayoutContainer>
   );
 }
+
+TaskDetail.propTypes = {
+  id: PropTypes.string,
+  student: PropTypes.string,
+  preview: PropTypes.bool,
+};

--- a/plugins/leemons-plugin-tasks/frontend/src/components/Student/TaskDetail/components/StepContainer/StepContainer.js
+++ b/plugins/leemons-plugin-tasks/frontend/src/components/Student/TaskDetail/components/StepContainer/StepContainer.js
@@ -4,6 +4,7 @@ import useStudentAssignationMutation from '@tasks/hooks/student/useStudentAssign
 import useTranslateLoader from '@multilanguage/useTranslateLoader';
 import { prefixPN } from '@tasks/helpers';
 import { useHistory } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import IntroductionStep from '../IntroductionStep/IntroductionStep';
 import DevelopmentStep from '../DevelopmentStep/DevelopmentStep';
 import { useUpdateTimestamps } from '../../__DEPRECATED__components/Steps/Steps';
@@ -58,7 +59,9 @@ export default function StepContainer({ preview, assignation, instance, scrollRe
         await updateTimestamp('end');
 
         history.push(`/private/tasks/correction/${instance.id}/${assignation?.user}?fromExecution`);
-      } catch (e) {}
+      } catch (e) {
+        console.error(e);
+      }
     }
   };
 
@@ -92,3 +95,13 @@ export default function StepContainer({ preview, assignation, instance, scrollRe
     </VerticalStepperContainer>
   );
 }
+
+StepContainer.propTypes = {
+  preview: PropTypes.bool,
+  assignation: PropTypes.object,
+  instance: PropTypes.object,
+  scrollRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
+};

--- a/plugins/leemons-plugin-tasks/frontend/src/components/Student/TaskDetail/components/SubmissionStep/SubmissionStep.js
+++ b/plugins/leemons-plugin-tasks/frontend/src/components/Student/TaskDetail/components/SubmissionStep/SubmissionStep.js
@@ -12,7 +12,7 @@ import {
 import { ChevLeftIcon } from '@bubbles-ui/icons/outline';
 import useTranslateLoader from '@multilanguage/useTranslateLoader';
 import { prefixPN } from '@tasks/helpers';
-import Link from './components/Link/Link';
+import { Link } from 'react-router-dom';
 import File from './components/File/File';
 import useSubmissionStepStyles from './SubmissionStep.style';
 
@@ -36,6 +36,9 @@ function SubmissionStep({
 
   const { classes } = useSubmissionStepStyles();
 
+  const isModulePreview = window?.location?.href?.includes('moduleId');
+  const moduleId = window?.location?.href?.split('moduleId=')[1];
+
   return (
     <TotalLayoutStepContainer
       stepName={stepName}
@@ -49,17 +52,23 @@ function SubmissionStep({
             </Button>
           }
           rightZone={
-            <Button
-              loading={isLoading}
-              onClick={async () => {
-                setIsLoading(true);
-                await onNextStep();
-                setIsLoading(false);
-              }}
-              disabled={!submission || preview}
-            >
-              {buttonsT('submit')}
-            </Button>
+            isModulePreview ? (
+              <Link to={`/private/learning-paths/modules/${moduleId}/view`}>
+                <Button variant="outline">{buttonsT('goBackToDashboardPreview')}</Button>
+              </Link>
+            ) : (
+              <Button
+                loading={isLoading}
+                onClick={async () => {
+                  setIsLoading(true);
+                  await onNextStep();
+                  setIsLoading(false);
+                }}
+                disabled={!submission || preview}
+              >
+                {buttonsT('submit')}
+              </Button>
+            )
           }
         />
       }

--- a/plugins/leemons-plugin-tests/backend/i18n/en.js
+++ b/plugins/leemons-plugin-tests/backend/i18n/en.js
@@ -272,6 +272,7 @@ module.exports = {
     questions: 'Questions',
     chartLabel: 'Composition of questions',
     showInTests: 'Preview',
+    goBackToDashboardPreview: 'Go back to dashboard',
   },
   testsCard: {
     view: 'Preview',

--- a/plugins/leemons-plugin-tests/backend/i18n/es.js
+++ b/plugins/leemons-plugin-tests/backend/i18n/es.js
@@ -270,6 +270,7 @@ module.exports = {
     questions: 'Preguntas',
     chartLabel: 'Composición de las preguntas',
     showInTests: 'Vista previa',
+    goBackToDashboardPreview: 'Volver al dashboard',
   },
   testsCard: {
     view: 'Vista previa',

--- a/plugins/leemons-plugin-tests/frontend/src/pages/private/tests/Detail.js
+++ b/plugins/leemons-plugin-tests/frontend/src/pages/private/tests/Detail.js
@@ -7,7 +7,6 @@ import {
   Loader,
   ImageLoader,
   AssetTestIcon,
-  LoadingOverlay,
   ContextContainer,
   ActivityAccordion,
   TotalLayoutHeader,
@@ -19,7 +18,7 @@ import {
 import useTranslateLoader from '@multilanguage/useTranslateLoader';
 import prefixPN from '@tests/helpers/prefixPN';
 import { useStore } from '@common';
-import { useHistory, useParams } from 'react-router-dom';
+import { useHistory, useParams, Link } from 'react-router-dom';
 import { addErrorAlert } from '@layout/alert';
 import { ChevronRightIcon } from '@bubbles-ui/icons/outline';
 import { forEach, keyBy } from 'lodash';
@@ -27,7 +26,6 @@ import { getProgramEvaluationSystemRequest } from '@academic-portfolio/request';
 import useLevelsOfDifficulty from '@assignables/components/LevelsOfDifficulty/hooks/useLevelsOfDifficulty';
 import useAssets from '@leebrary/request/hooks/queries/useAssets';
 import useAssignables from '@assignables/requests/hooks/queries/useAssignables';
-import useUserAgents from '@users/hooks/useUserAgents';
 import { useIsOwner } from '@leebrary/hooks/useIsOwner';
 import { getTestRequest } from '../../../request';
 import QuestionsTable from './components/QuestionsTable';
@@ -43,6 +41,8 @@ export default function Detail() {
   const { classes: styles } = ResultStyles({}, { name: 'Detail' });
   const levels = useLevelsOfDifficulty(true);
   const scrollRef = useRef();
+  const isModulePreview = window?.location?.href?.includes('moduleId');
+  const moduleId = window?.location?.href?.split('moduleId=')[1];
 
   const [store, render] = useStore({
     loading: true,
@@ -257,7 +257,7 @@ export default function Detail() {
           icon={<AssetTestIcon />}
           direction="row"
         >
-          {!assignableLoading && !assetsLoading && canEdit && (
+          {!isModulePreview && !assignableLoading && !assetsLoading && canEdit && (
             <Stack spacing={4}>
               <Button variant="outline" onClick={() => goEditPage()}>
                 {t('edit')}
@@ -267,7 +267,12 @@ export default function Detail() {
               </Button>
             </Stack>
           )}
-          {(assignableLoading || assetsLoading) && <Loader visible />}
+          {isModulePreview && (
+            <Link to={`/private/learning-paths/modules/${moduleId}/view`}>
+              <Button variant="outline">{t('goBackToDashboardPreview')}</Button>
+            </Link>
+          )}
+          {!isModulePreview && (assignableLoading || assetsLoading) && <Loader visible />}
         </TotalLayoutHeader>
       }
     >

--- a/plugins/leemons-plugin-tests/frontend/src/pages/private/tests/Detail.js
+++ b/plugins/leemons-plugin-tests/frontend/src/pages/private/tests/Detail.js
@@ -239,7 +239,12 @@ export default function Detail() {
                   {t('showInTests')}
                 </Button>
               </Box>
-              <QuestionsTable withStyle hideCheckbox questions={store.test?.questions} />
+              <QuestionsTable
+                withStyle
+                hideCheckbox
+                questions={store.test?.questions}
+                hideOpenIcon={isModulePreview}
+              />
             </>
           )}
         </Box>

--- a/plugins/leemons-plugin-tests/frontend/src/pages/private/tests/Detail.js
+++ b/plugins/leemons-plugin-tests/frontend/src/pages/private/tests/Detail.js
@@ -20,7 +20,7 @@ import prefixPN from '@tests/helpers/prefixPN';
 import { useStore } from '@common';
 import { useHistory, useParams, Link } from 'react-router-dom';
 import { addErrorAlert } from '@layout/alert';
-import { ChevronRightIcon } from '@bubbles-ui/icons/outline';
+import { ChevRightIcon } from '@bubbles-ui/icons/outline';
 import { forEach, keyBy } from 'lodash';
 import { getProgramEvaluationSystemRequest } from '@academic-portfolio/request';
 import useLevelsOfDifficulty from '@assignables/components/LevelsOfDifficulty/hooks/useLevelsOfDifficulty';
@@ -235,7 +235,7 @@ export default function Detail() {
           ) : (
             <>
               <Box className={styles.showTestBar}>
-                <Button rounded rightIcon={<ChevronRightIcon />} onClick={toggleQuestionMode}>
+                <Button rounded rightIcon={<ChevRightIcon />} onClick={toggleQuestionMode}>
                   {t('showInTests')}
                 </Button>
               </Box>

--- a/plugins/leemons-plugin-tests/frontend/src/pages/private/tests/StudentInstance/components/QuestionList.js
+++ b/plugins/leemons-plugin-tests/frontend/src/pages/private/tests/StudentInstance/components/QuestionList.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useStore } from '@common';
+import { Button, Stack } from '@bubbles-ui/components';
+import { ChevLeftIcon } from '@bubbles-ui/icons/outline';
 import Question from './Question';
 
 export default function QuestionList(props) {
@@ -12,30 +14,37 @@ export default function QuestionList(props) {
   const question = props.store.questions[store.questionNumber];
 
   return (
-    <Question
-      {...props}
-      prevStep={() => {
-        if (store.questionNumber > 0) {
-          store.questionNumber -= 1;
-          render();
-        } else {
-          props.prevStep();
-        }
-      }}
-      nextStep={(e) => {
-        if (isLast) {
-          props.finishStep(e);
-        } else {
-          store.questionNumber += 1;
-          render();
-          // props.nextStep(e);
-        }
-      }}
-      question={question}
-      index={store.questionNumber}
-      isLast={isLast}
-      saveQuestion={() => props.saveQuestion(question.id)}
-    />
+    <Stack fullWidth spacing={4} direction="column">
+      <Stack justifyContent="end" sx={() => ({ marginTop: 16, marginRight: 12 })}>
+        <Button onClick={props.onReturn} leftIcon={<ChevLeftIcon />}>
+          {props.t('returnToTable')}
+        </Button>
+      </Stack>
+      <Question
+        {...props}
+        prevStep={() => {
+          if (store.questionNumber > 0) {
+            store.questionNumber -= 1;
+            render();
+          } else {
+            props.prevStep();
+          }
+        }}
+        nextStep={(e) => {
+          if (isLast) {
+            props.finishStep(e);
+          } else {
+            store.questionNumber += 1;
+            render();
+            // props.nextStep(e);
+          }
+        }}
+        question={question}
+        index={store.questionNumber}
+        isLast={isLast}
+        saveQuestion={() => props.saveQuestion(question.id)}
+      />
+    </Stack>
   );
 }
 
@@ -53,4 +62,5 @@ QuestionList.propTypes = {
   index: PropTypes.number,
   finishStep: PropTypes.func,
   saveQuestion: PropTypes.func,
+  onReturn: PropTypes.func,
 };


### PR DESCRIPTION
fix(transversal): on a module preview, if user enter on a atom preview, show button to go back to module preview dashboard