### PR TITLE
fix(cCreator): Move `goBackToDashboard` button to `rightZone` prop

### DIFF
--- a/plugins/leemons-plugin-content-creator/frontend/src/pages/Detail/index.js
+++ b/plugins/leemons-plugin-content-creator/frontend/src/pages/Detail/index.js
@@ -218,13 +218,15 @@ export default function Index({ isNew, readOnly }) {
             compact
             mainActionLabel={t('cancel')}
             cancelable={!readOnly}
-            direction="row"
+            rightZone={
+              isModulePreview && (
+                <Link to={`/private/learning-paths/modules/${moduleId}/view`}>
+                  <Button variant="outline">{t('goBackToDashboardPreview')}</Button>
+                </Link>
+              )
+            }
           >
-            {isModulePreview && (
-              <Link to={`/private/learning-paths/modules/${moduleId}/view`}>
-                <Button variant="outline">{t('goBackToDashboardPreview')}</Button>
-              </Link>
-            )}
+
             {!readOnly && <div id="toolbar-div" style={{ width: '100%' }} ref={toolbarRef}></div>}
           </TotalLayoutHeader>
         }


### PR DESCRIPTION
fix(content-creator): Move "goBackToDashboard" button to "rightZone" prop in TotalLayoutHeader