### PR TITLE
fix(user): Add user activation handling

### DIFF
--- a/plugins/leemons-plugin-users/frontend/src/components/UserAdminDrawer/UserAdminDrawer.js
+++ b/plugins/leemons-plugin-users/frontend/src/components/UserAdminDrawer/UserAdminDrawer.js
@@ -183,6 +183,10 @@ function UserAdminDrawer({ user: value, center, opened, onClose = noop, onSave =
     }
   }
 
+  function handleActivateUser(active) {
+    setUser({ ...user, active });
+  }
+
   React.useEffect(() => {
     if (opened) {
       refreshUserAgents();
@@ -311,7 +315,12 @@ function UserAdminDrawer({ user: value, center, opened, onClose = noop, onSave =
             />
           </ContextContainer>
 
-          <UserForm user={user} onCheckEmail={checkEmail} isAdminFirstTime={isAdminFirstTime} />
+          <UserForm
+            user={user}
+            onCheckEmail={checkEmail}
+            isAdminFirstTime={isAdminFirstTime}
+            onActivateUser={handleActivateUser}
+          />
 
           <ContextContainer title={t('tagsHeader')}>
             <Controller

--- a/plugins/leemons-plugin-users/frontend/src/components/UserForm.js
+++ b/plugins/leemons-plugin-users/frontend/src/components/UserForm.js
@@ -25,7 +25,7 @@ import { SetPasswordModal } from './SetPasswordModal';
 
 const USER_FIELDS = ['email', 'name', 'surnames', 'secondSurname', 'gender', 'birthdate', 'avatar'];
 
-function UserForm({ user, isAdminFirstTime, onCheckEmail = noop }) {
+function UserForm({ user, isAdminFirstTime, onCheckEmail = noop, onActivateUser = noop }) {
   const [reload, setReload] = React.useState(false);
   const [activeModalOpened, setActiveModalOpened] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
@@ -118,10 +118,12 @@ function UserForm({ user, isAdminFirstTime, onCheckEmail = noop }) {
 
       addSuccessAlert(t('activatedUser'));
       toggleModal();
+      onActivateUser(true);
       updateUserDetails();
       setLoading(false);
     } catch (err) {
       addErrorAlert(err);
+      onActivateUser(false);
       setLoading(false);
     }
   };
@@ -319,6 +321,7 @@ UserForm.propTypes = {
   user: PropTypes.object,
   onCheckEmail: PropTypes.func,
   isAdminFirstTime: PropTypes.bool,
+  onActivateUser: PropTypes.func,
 };
 
 export { UserForm, USER_FIELDS };


### PR DESCRIPTION
In UserAdminDrawer and UserForm components

- Added `handleActivateUser` function in `UserAdminDrawer` to update user activation status.
- Passed `onActivateUser` prop to `UserForm` to handle user activation.
- Updated `UserForm` to call `onActivateUser` on user activation success or failure.
- Updated prop types in `UserForm` to include `onActivateUser`.