### PR TITLE
feat(scripts): exportBulkTemplates

### DIFF
--- a/scripts/exportBulkTemplates.js
+++ b/scripts/exportBulkTemplates.js
@@ -50,7 +50,7 @@ const s3 = new aws.S3({
 });
 
 // DB CONFIG ·························································································································||
-const localDB = 'leemons'; //! TEMPLAT B ESTÁ EN OTRA BASE DE DATOS dev === 'test', produ === 'leemons'
+const localDB = 'leemons-production-templates'; //! Template B comes from a dev enviroment DB. dev === 'leemons-development-templates', produ === 'leemons-production-templates'
 
 const dbUri =
   process.env.MONGODB_URI || process.env.MONGO_URI || `mongodb://localhost:27017/${localDB}`; // defaults to local db
@@ -260,9 +260,6 @@ const processLoginAndBulkData = async () => {
 
 (async () => {
   try {
-    console.log(
-      'TEMPLATE B SE HIZO EN ENTORNO DEV!!! ASEGURAR QUE DB Y .ENV ESTA APUNTANDO A DONDE TIENE QUE. LAS DEMS EN APP'
-    );
     const templateInfo = TEMPLATES_INFO[templateKey];
 
     if (!templateInfo) {


### PR DESCRIPTION
- Remove logs and improve comments for the use of the `exportBulkTemplates` script
- Set a clearer name for local databases holding the deployments for the different templates (these are currently the source of truth, as they have been updated locally and differ from the original production deployments).