### PR TITLE
fix(dataset-form): handle required fields specific to profile

### DIFF
--- a/plugins/leemons-plugin-dataset/frontend/src/components/DatasetForm/DatasetForm.js
+++ b/plugins/leemons-plugin-dataset/frontend/src/components/DatasetForm/DatasetForm.js
@@ -187,6 +187,19 @@ const DatasetForm = forwardRef(
         return false;
       }
 
+      let toSave = form.getValues();
+
+      const requiredOnlyForMe = getRequiredKeysOnlyForMe({ dataset, profileId });
+
+      if (requiredOnlyForMe.length === 0) {
+        toSave = _.pickBy(toSave, (value) => !!value.value);
+        return handleSave(toSave, forceTargetId);
+      }
+
+      const readOnlyKeys = dataset.compileJsonSchema?.required.filter(
+        (key) => !requiredOnlyForMe.includes(key)
+      );
+
       await form.submit();
 
       // Process form results
@@ -195,10 +208,6 @@ const DatasetForm = forwardRef(
       if (errors.length && !skipOptional) {
         return null;
       }
-
-      const readOnlyKeys = dataset.compileJsonSchema?.required.filter(
-        (key) => !getRequiredKeysOnlyForMe({ dataset, profileId }).includes(key)
-      );
 
       const areOptional = areOptionalKeys({
         errors,
@@ -209,7 +218,7 @@ const DatasetForm = forwardRef(
         return false; // Invalid form
       }
 
-      return handleSave(form.getValues(), forceTargetId);
+      return handleSave(toSave, forceTargetId);
     }
 
     useImperativeHandle(ref, () => ({


### PR DESCRIPTION
- Refactor to save form values conditionally based on required fields specific to the profile.
- Ensure read-only keys are correctly identified and handled.
- Adjust form submission logic to accommodate new required fields handling.