### PR TITLE
Error en maqueta de calendar cuando el mes tiene 6 semanas

### DIFF
--- a/plugins/leemons-plugin-calendar/frontend/src/widgets/user-program-calendar/components/Calendar/Calendar.styles.js
+++ b/plugins/leemons-plugin-calendar/frontend/src/widgets/user-program-calendar/components/Calendar/Calendar.styles.js
@@ -9,6 +9,7 @@ const CalendarStyles = createStyles((theme) => {
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'space-between',
+      gap: 16,
       '.react-calendar__tile': {
         maxWidth: '100%',
         paddingBottom: '16px !important',


### PR DESCRIPTION
fix(calendar):
- user-program-calendar (Dashboard widget): add gap between calendar and legend (elements in column)