### PR TITLE
fix(feedback): survey questions were not duplicated with the feedback

### DIFF
--- a/plugins/leemons-plugin-feedback/backend/core/feedback/duplicateFeedback.js
+++ b/plugins/leemons-plugin-feedback/backend/core/feedback/duplicateFeedback.js
@@ -1,11 +1,12 @@
 /* eslint-disable no-param-reassign */
 const _ = require('lodash');
+
 const getQuestionsByFeedbackIds = require('../feedback-questions/getQuestionsByFeedbackIds');
 
 async function duplicateFeedback({ id, published, ctx }) {
   const newAssignable = await ctx.tx.call('assignables.assignables.duplicateAssignable', {
     assignableId: id,
-    published,
+    published: false, // forced to false to avoid the creation of different versions of the assignable when updating later in this function
   });
 
   const questions = await getQuestionsByFeedbackIds({ id, ctx });
@@ -59,6 +60,7 @@ async function duplicateFeedback({ id, published, ctx }) {
     newAssignable.metadata.featuredImage = newFeaturedImage.id;
     await ctx.tx.call('assignables.assignables.updateAssignable', {
       assignable: newAssignable,
+      published,
     });
   }
 


### PR DESCRIPTION
Questions are no longer lost when duplicating a survey with a featured image.

Updating the previously duplicated assignable was causing a new version to be created, resulting in the new survey’s questions pointing to the wrong assignable version.

This fix prevents the creation of new assignable versions while maintaining the existing logic to determine whether the duplicated survey is published. Currently, this is defined by a parameter from the frontend set to true