### PR TITLE
fix(feedback): redirect student to the expected page

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,7 @@
     "plugin:react/recommended",
     // If using the new JSX transform from React 17
     // https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports
-    // "plugin:react/jsx-runtime",
+    "plugin:react/jsx-runtime",
     "plugin:react-hooks/recommended",
 
     "plugin:sonarjs/recommended-legacy",
@@ -54,7 +54,6 @@
     "no-plusplus": "off",
     "no-unused-vars": "warn",
     "no-underscore-dangle": "off",
-    "react/react-in-jsx-scope": "off",
     "import/no-deprecated": "warn",
     "import/no-extraneous-dependencies": "off",
     "import/no-mutable-exports": "error",

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -8,7 +8,7 @@
       "ESNext"
     ],
     "module": "ESNext",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "allowJs": true,
     "paths": {
       "@academic-calendar/*": [

--- a/packages/leemons-react/src/webpack/webpack.config.js
+++ b/packages/leemons-react/src/webpack/webpack.config.js
@@ -189,7 +189,14 @@ module.exports = function webpackConfig({
                 {
                   loader: 'babel-loader',
                   options: {
-                    presets: ['@babel/preset-react'],
+                    presets: [
+                      [
+                        '@babel/preset-react',
+                        {
+                          runtime: 'automatic',
+                        },
+                      ],
+                    ],
                     plugins: [isDev && require.resolve('react-refresh/babel')].filter(Boolean),
                     cacheDirectory: true,
                     cacheCompression: false,

--- a/plugins/leemons-plugin-feedback/frontend/src/pages/private/feedback/Result/index.js
+++ b/plugins/leemons-plugin-feedback/frontend/src/pages/private/feedback/Result/index.js
@@ -1,14 +1,12 @@
 import React, { useRef } from 'react';
 import { useHistory, useParams, Link } from 'react-router-dom';
 
-import { addErrorAlert } from '@layout/alert';
-import { createDatasheet } from '@feedback/helpers/createDatasheet';
-import ActivityHeader from '@assignables/components/ActivityHeader/index';
-import useInstances from '@assignables/requests/hooks/queries/useInstances';
 
 import { useIsTeacher } from '@academic-portfolio/hooks';
+import ActivityHeader from '@assignables/components/ActivityHeader/index';
 import useNextActivityUrl from '@assignables/hooks/useNextActivityUrl';
 import getAssignableInstance from '@assignables/requests/assignableInstances/getAssignableInstance';
+import useInstances from '@assignables/requests/hooks/queries/useInstances';
 import {
   Badge,
   Box,
@@ -24,12 +22,15 @@ import {
 } from '@bubbles-ui/components';
 import { ChevRightIcon, DownloadIcon } from '@bubbles-ui/icons/outline';
 import { htmlToText, useSearchParams, useStore } from '@common';
+import { addErrorAlert } from '@layout/alert';
 import useTranslateLoader from '@multilanguage/useTranslateLoader';
 import { prefixPN as tasksPrefixPN } from '@tasks/helpers';
+import { useUserAgents } from '@users/hooks';
 
 import ResultStyles from './Result.styles';
 import { OpenResponse, SelectResponse } from './components';
 
+import { createDatasheet } from '@feedback/helpers/createDatasheet';
 import prefixPN from '@feedback/helpers/prefixPN';
 import { LikertStatistics } from '@feedback/pages/private/feedback/Result/components/LikertStatistics';
 import { NPSStatistics } from '@feedback/pages/private/feedback/Result/components/NPSStatistics';
@@ -63,7 +64,8 @@ export default function Result() {
   const params = useParams();
   const scrollRef = useRef();
 
-  const nextActivityUrl = useNextActivityUrl(store.assignation);
+  const user = useUserAgents();
+  const nextActivityUrl = useNextActivityUrl({instance: store.instance, user: user[0]});
 
   const { data: dynamicInstance } = useInstances({ id: params.id });
   const { classes } = ResultStyles({}, { name: 'Result' });

--- a/plugins/leemons-plugin-feedback/frontend/src/pages/private/feedback/StudentInstance/components/QuestionsStep.js
+++ b/plugins/leemons-plugin-feedback/frontend/src/pages/private/feedback/StudentInstance/components/QuestionsStep.js
@@ -1,15 +1,10 @@
-import PropTypes from 'prop-types';
 import React, { useMemo } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 import {
   Box,
   Button,
   createStyles,
-  Modal,
-  Paragraph,
-  Stack,
-  DropdownButton,
   ContextContainer,
   TotalLayoutStepContainer,
   TotalLayoutFooterContainer,
@@ -17,20 +12,20 @@ import {
 import {
   ChevRightIcon,
   ChevLeftIcon,
-  ChevronRightIcon,
-  ExpandDiagonalIcon,
 } from '@bubbles-ui/icons/outline';
 import { useStore } from '@common';
-import prefixPN from '@feedback/helpers/prefixPN';
-import SelectResponseQuestion from '@feedback/pages/private/feedback/StudentInstance/components/questions/SelectResponseQuestion';
-import { setQuestionResponseRequest } from '@feedback/request';
 import useTranslateLoader from '@multilanguage/useTranslateLoader';
-
-import { setInstanceTimestamp } from '@feedback/request/feedback';
 import { isNil } from 'lodash';
+import PropTypes from 'prop-types';
+
 import LikertResponse from './LikertResponse';
 import NetPromoterScoreResponse from './NetPromoterScoreResponse';
 import OpenResponse from './OpenResponse';
+
+import prefixPN from '@feedback/helpers/prefixPN';
+import SelectResponseQuestion from '@feedback/pages/private/feedback/StudentInstance/components/questions/SelectResponseQuestion';
+import { setQuestionResponseRequest } from '@feedback/request';
+import { setInstanceTimestamp } from '@feedback/request/feedback';
 
 export const Styles = createStyles((theme, { viewMode }) => ({
   container: {
@@ -132,7 +127,13 @@ function QuestionsStep({
     } else {
       if (!viewMode) setInstanceTimestamp(instanceId, 'end', userId);
 
-      goToResults();
+      if (instance.showResults) {
+        goToResults();
+      } else if (isModule) {
+        gotToModuleDashboard();
+      } else {
+        goToOnGoing();
+      }
     }
 
     render();

--- a/plugins/leemons-plugin-feedback/frontend/src/widgets/assignables/AssignmentDrawer.js
+++ b/plugins/leemons-plugin-feedback/frontend/src/widgets/assignables/AssignmentDrawer.js
@@ -1,9 +1,10 @@
-import React, { useEffect, useCallback } from 'react';
-import PropTypes from 'prop-types';
+import { useEffect, useCallback } from 'react';
+import { useForm, FormProvider, Controller } from 'react-hook-form';
+
 import { useFormLocalizations } from '@assignables/components/Assignment/Form';
 import { OtherOptions } from '@assignables/components/Assignment/components/OtherOptions';
-import { useForm, FormProvider, Controller } from 'react-hook-form';
 import { Box, Button, TotalLayoutFooterContainer, ContextContainer } from '@bubbles-ui/components';
+import PropTypes from 'prop-types';
 
 export default function AssignmentDrawer({ assignable, value, onSave, onClose, scrollRef }) {
   const form = useForm({ defaultValues: value });
@@ -61,7 +62,7 @@ export default function AssignmentDrawer({ assignable, value, onSave, onClose, s
   );
 }
 
-AssignmentDrawer.defaultValues = () => ({ showResults: true });
+AssignmentDrawer.defaultValues = () => ({ showResults: false });
 
 AssignmentDrawer.propTypes = {
   assignable: PropTypes.object,

--- a/tsconfig.frontend.json
+++ b/tsconfig.frontend.json
@@ -8,7 +8,7 @@
       "ESNext"
     ],
     "module": "ESNext",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
When the student finished a feedback it was always redirected to the results page, which throws an error if is disabled for students.
Now it redirects correctly to the results page if is enabled, otherwise to the module dashboard if is a module or to the ongoing activities.

fix(feedback): module assignments hide results by default

fix(feedback): show next activity url in the results page
