### PR TITLE
fix(leebrary): set default player display for media resources

### DIFF
--- a/plugins/leemons-plugin-leebrary/frontend/src/components/LibraryCardCC/components/LibraryCardCCFooter/LibraryCardCCFooter.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/LibraryCardCC/components/LibraryCardCCFooter/LibraryCardCCFooter.js
@@ -1,18 +1,15 @@
-import React from 'react';
 import { Box, FileIcon, Text } from '@bubbles-ui/components';
 import { DownloadIcon } from '@bubbles-ui/icons/outline';
-import { LibraryCardCCFooterStyles } from './LibraryCardCCFooter.styles';
+
 import {
   LIBRARY_CARD_CC_FOOTER_PROPTYPES,
   LIBRARY_CARD_CC_FOOTER_DEFAULTPROPS,
 } from './LibraryCardCCFooter.constants';
+import { LibraryCardCCFooterStyles } from './LibraryCardCCFooter.styles';
 
 const LibraryCardCCFooter = ({ fileType, fileExtension, variant }) => {
   const { classes } = LibraryCardCCFooterStyles();
   const variantIconLabel = fileType?.charAt(0)?.toUpperCase() + fileType?.slice(1);
-
-  console.log('fileType in LibraryCardCCFooter', fileType);
-  console.log('variantIconLabel in LibraryCardCCFooter', variantIconLabel);
 
   return (
     <Box className={classes.root}>

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/LibraryTool/LibraryModal.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/LibraryTool/LibraryModal.js
@@ -80,7 +80,11 @@ const LibraryModal = ({
       onChange({
         width: '100%',
         align: 'left',
-        display: ['image', 'video'].includes(preparedAsset.fileType) ? 'player' : 'embed',
+        display:
+          ['image', 'video', 'audio'].includes(preparedAsset.fileType) ||
+          (preparedAsset.fileType === 'bookmark' && preparedAsset.mediaType === 'video')
+            ? 'player'
+            : 'embed',
         asset: preparedAsset,
         readOnly,
       });


### PR DESCRIPTION
fix(leebrary): Content creator. Audio resources, video resources and bookmarks as video, default display: player. Remove logs from LibraryCardCCFooter