### PR TITLE
fix(leebrary): pass translation prop to bulk assets components

### DIFF
--- a/plugins/leemons-plugin-leebrary/frontend/src/pages/private/assets/BulkAssetPage.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/pages/private/assets/BulkAssetPage.js
@@ -256,6 +256,7 @@ const BulkAssetPage = () => {
           initialData={createdAssets}
           assets={createdAssets}
           onAssetsUpdate={handleAssetsUpdate}
+          t={t}
         />
       )}
     </TotalLayoutContainer>


### PR DESCRIPTION
 fix(leebrary): pass "t" param from BulkAssetPage to ManageBulkAssets component. ManageBulkAssets is waiting to this prop and thow an error because the component and his childrens can't find this prop.