### PR TITLE
feat(scores): implement manual activities with grading functionality

### DIFF
--- a/packages/leemons-mongodb/src/index.js
+++ b/packages/leemons-mongodb/src/index.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+
 const { mixin } = require('./mixin');
 
 module.exports = {
@@ -27,5 +28,19 @@ module.exports = {
       return connection.models[modelName];
     }
     return connection.model(modelName, schema);
+  },
+
+  leemonsSchemaFields: {
+    id: {
+      type: String,
+      required: true,
+      unique: true,
+      index: true,
+    },
+    deploymentID: {
+      type: String,
+      required: true,
+      index: true,
+    },
   },
 };

--- a/packages/leemons-mongodb/src/types.d.ts
+++ b/packages/leemons-mongodb/src/types.d.ts
@@ -90,3 +90,17 @@ export type PaginatedQueryResult<T> = {
 };
 
 export type PipelineStage = import('mongoose').PipelineStage;
+
+export const leemonsSchemaFields = {
+  id: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true,
+  },
+  deploymentID: {
+    type: String,
+    required: true,
+    index: true,
+  },
+} as const;

--- a/packages/leemons-validator/package.json
+++ b/packages/leemons-validator/package.json
@@ -26,6 +26,7 @@
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "ajv-keywords": "^5.1.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "@leemons/lrn": "0.0.41"
   }
 }

--- a/packages/leemons-validator/src/validator.js
+++ b/packages/leemons-validator/src/validator.js
@@ -1,7 +1,9 @@
-const _ = require('lodash');
+const { isLRN } = require('@leemons/lrn');
 const Ajv = require('ajv');
 const addFormats = require('ajv-formats');
 const addKeywords = require('ajv-keywords');
+const _ = require('lodash');
+
 const { localeRegex } = require('./validations/localeCode');
 
 const ajv = new Ajv({ allErrors: true });
@@ -40,6 +42,10 @@ class LeemonsValidator {
 // Validaciones de tipos custom
 ajv.addFormat('localeCode', {
   validate: (x) => localeRegex.test(x),
+});
+
+ajv.addFormat('lrn', {
+  validate: isLRN,
 });
 
 LeemonsValidator.ajv = ajv;

--- a/plugins/leemons-plugin-assignables/backend/core/ongoing/helpers/activitiesData/getInstancesData.js
+++ b/plugins/leemons-plugin-assignables/backend/core/ongoing/helpers/activitiesData/getInstancesData.js
@@ -14,6 +14,7 @@ async function getInstancesData({ instances, relatedInstances = false, ctx }) {
         'id',
         'assignable',
         'alwaysAvailable',
+        'gradable',
         'requiresScoring',
         'allowFeedback',
         'metadata',

--- a/plugins/leemons-plugin-assignables/backend/core/ongoing/helpers/filters/filterInstancesByEvaluable.js
+++ b/plugins/leemons-plugin-assignables/backend/core/ongoing/helpers/filters/filterInstancesByEvaluable.js
@@ -1,10 +1,13 @@
 const { filter } = require('lodash');
 
-function filterInstancesByEvaluable({ instances, evaluable }) {
-  return filter(
-    instances,
-    (instance) => instance.requiresScoring || instance.allowFeedback === Boolean(evaluable)
-  );
+function filterInstancesByEvaluable({ instances, evaluable, calificableOnly }) {
+  return filter(instances, (instance) => {
+    if (calificableOnly) {
+      return instance.gradable === true;
+    }
+
+    return instance.requiresScoring === Boolean(evaluable);
+  });
 }
 
 module.exports = { filterInstancesByEvaluable };

--- a/plugins/leemons-plugin-assignables/backend/core/ongoing/searchInstances.js
+++ b/plugins/leemons-plugin-assignables/backend/core/ongoing/searchInstances.js
@@ -1,5 +1,7 @@
 const { map, keyBy } = require('lodash');
 
+const { filterByInstanceDates } = require('../instances/searchInstances/filterByInstanceDates');
+
 const {
   getTeacherInstances,
   getInstanceSubjectsProgramsAndClasses,
@@ -14,11 +16,11 @@ const {
   filterAssignationsByProgress,
 } = require('./helpers/filters');
 const { sortInstancesByDates, applyOffsetAndLimit } = require('./helpers/sorts');
-const { filterByInstanceDates } = require('../instances/searchInstances/filterByInstanceDates');
 
 async function searchInstances({ query, ctx }) {
   const isTeacher = [true, 1, 'true'].includes(query?.isTeacher);
   const isEvaluable = [true, 1, 'true'].includes(query?.isEvaluable);
+  const calificableOnly = [true, 1, 'true'].includes(query?.calificableOnly);
 
   /*
     === Teacher ===
@@ -28,7 +30,11 @@ async function searchInstances({ query, ctx }) {
     let instances = await getTeacherInstances({ ctx });
 
     instances = filterInstancesByRoleAndQuery({ instances, filters: query });
-    instances = filterInstancesByEvaluable({ instances, evaluable: isEvaluable });
+    instances = filterInstancesByEvaluable({
+      instances,
+      evaluable: isEvaluable,
+      calificableOnly,
+    });
 
     const instanceSubjectsProgramsAndClasses = await getInstanceSubjectsProgramsAndClasses({
       instances,
@@ -63,7 +69,11 @@ async function searchInstances({ query, ctx }) {
     filters: query,
   });
 
-  instances = filterInstancesByEvaluable({ instances, evaluable: isEvaluable });
+  instances = filterInstancesByEvaluable({
+    instances,
+    evaluable: isEvaluable,
+    calificableOnly,
+  });
 
   const instanceSubjectsProgramsAndClasses = await getInstanceSubjectsProgramsAndClasses({
     instances,

--- a/plugins/leemons-plugin-assignables/backend/core/ongoing/searchOngoingActivities.js
+++ b/plugins/leemons-plugin-assignables/backend/core/ongoing/searchOngoingActivities.js
@@ -14,10 +14,10 @@ const {
   filterInstancesByStatusAndArchived,
   filterInstancesByNotModule,
 } = require('./helpers/filters');
-const { applyOffsetAndLimit, sortInstancesByDates } = require('./helpers/sorts');
 const { filterInstancesByIsModule } = require('./helpers/filters/filterInstancesByIsModule');
 const { groupInstancesInModules } = require('./helpers/filters/groupInstancesInModules');
 const { returnModulesData } = require('./helpers/filters/returnModulesData');
+const { applyOffsetAndLimit, sortInstancesByDates } = require('./helpers/sorts');
 
 /*
   === Main function ===

--- a/plugins/leemons-plugin-learning-paths/frontend/src/components/ModuleDashboard/components/DashboardCard/components/ScoreFeedback/ScoreFeedback.js
+++ b/plugins/leemons-plugin-learning-paths/frontend/src/components/ModuleDashboard/components/DashboardCard/components/ScoreFeedback/ScoreFeedback.js
@@ -1,17 +1,19 @@
-import React, { useMemo, useState, useEffect } from 'react';
-import { Box, Text, Badge, TextClamp } from '@bubbles-ui/components';
+import React, { useMemo, useState } from 'react';
+
 import useProgramEvaluationSystem from '@assignables/hooks/useProgramEvaluationSystem';
-import _, { cloneDeep, isNil, sortBy } from 'lodash';
-import useTranslateLoader from '@multilanguage/useTranslateLoader';
+import { Box, Text, Badge, TextClamp } from '@bubbles-ui/components';
 import { unflatten } from '@common';
-import { GotFeedbackIcon } from './GotFeedbackIcon';
-import { useScoreFeedbackStyles } from './ScoreFeedback.styles';
+import useTranslateLoader from '@multilanguage/useTranslateLoader';
+import _, { isNil, sortBy } from 'lodash';
+
 import prefixPN from '../../../../../../helpers/prefixPN';
-import { ArrowComponent } from './ArrowComponent/ArrowComponent';
+
+import { GotFeedbackIcon } from './GotFeedbackIcon';
 import { SCOREFEEDBACK_DEFAULT_PROPS, SCOREFEEDBACK_PROP_TYPES } from './ScoreFeedback.constants';
+import { useScoreFeedbackStyles } from './ScoreFeedback.styles';
 
 export function findNearestFloorScore(score, scales) {
-  const sortedScales = sortBy(cloneDeep(scales), 'number');
+  const sortedScales = sortBy(scales, 'number');
   let nearestScore = null;
   let distance = Infinity;
   const { length } = sortedScales;
@@ -25,7 +27,7 @@ export function findNearestFloorScore(score, scales) {
 
     const currentDistance = Math.abs(scale.number - score);
 
-    if (currentDistance < distance) {
+    if (currentDistance <= distance) {
       nearestScore = scale;
       distance = currentDistance;
     } else {

--- a/plugins/leemons-plugin-scores/backend/config/constants.js
+++ b/plugins/leemons-plugin-scores/backend/config/constants.js
@@ -1,12 +1,13 @@
-const pluginName = 'scores';
+const PLUGIN_NAME = 'scores';
+const VERSION = 1;
 
 const permissionNames = {
-  periods: `${pluginName}.periods`,
-  noteBook: `${pluginName}.notebook`,
-  scores: `${pluginName}.scores`,
-  scoresMenu: `${pluginName}.scoresMenu`,
-  reviewer: `${pluginName}.reviewer`,
-  weights: `${pluginName}.weights`,
+  periods: `${PLUGIN_NAME}.periods`,
+  noteBook: `${PLUGIN_NAME}.notebook`,
+  scores: `${PLUGIN_NAME}.scores`,
+  scoresMenu: `${PLUGIN_NAME}.scoresMenu`,
+  reviewer: `${PLUGIN_NAME}.reviewer`,
+  weights: `${PLUGIN_NAME}.weights`,
 };
 
 const permissions = [
@@ -170,7 +171,8 @@ const menuItems = [
 ];
 
 module.exports = {
-  pluginName,
+  PLUGIN_NAME,
+  VERSION,
 
   permissionNames,
   permissions,

--- a/plugins/leemons-plugin-scores/backend/core/manualActivities/add.js
+++ b/plugins/leemons-plugin-scores/backend/core/manualActivities/add.js
@@ -1,0 +1,11 @@
+const { validateManualActivity } = require('./validations/validateManualActivity');
+
+async function addManualActivity({ manualActivity, ctx }) {
+  validateManualActivity({ manualActivity, ctx });
+
+  const { id } = await ctx.tx.db.ManualActivities.create(manualActivity);
+
+  return id;
+}
+
+module.exports = addManualActivity;

--- a/plugins/leemons-plugin-scores/backend/core/manualActivities/list.js
+++ b/plugins/leemons-plugin-scores/backend/core/manualActivities/list.js
@@ -1,18 +1,22 @@
-async function listManualActivitiesForClassAndPeriod({ classId, startDate, endDate, ctx }) {
-  return await ctx.tx.db.ManualActivities.find({
+const { escapeRegExp } = require('lodash');
+
+async function listManualActivitiesForClassAndPeriod({ classId, startDate, endDate, search, ctx }) {
+  const query = {
     classId,
     date: {
       $gte: startDate,
       $lte: endDate,
     },
-  }).select({
-    _id: 0,
-    id: 1,
-    name: 1,
-    description: 1,
-    date: 1,
-    classId: 1,
-  });
+  };
+
+  if (search) {
+    query.name = {
+      $regex: escapeRegExp(search.trim()),
+      $options: 'i',
+    };
+  }
+
+  return await ctx.tx.db.ManualActivities.find(query).lean();
 }
 
 module.exports = listManualActivitiesForClassAndPeriod;

--- a/plugins/leemons-plugin-scores/backend/core/manualActivities/list.js
+++ b/plugins/leemons-plugin-scores/backend/core/manualActivities/list.js
@@ -4,10 +4,17 @@ async function listManualActivitiesForClassAndPeriod({ classId, startDate, endDa
   const query = {
     classId,
     date: {
-      $gte: startDate,
-      $lte: endDate,
+      $exists: true,
     },
   };
+
+  if (startDate) {
+    query.date.$gte = startDate;
+  }
+
+  if (endDate) {
+    query.date.$lte = endDate;
+  }
 
   if (search) {
     query.name = {

--- a/plugins/leemons-plugin-scores/backend/core/manualActivities/list.js
+++ b/plugins/leemons-plugin-scores/backend/core/manualActivities/list.js
@@ -1,0 +1,18 @@
+async function listManualActivitiesForClassAndPeriod({ classId, startDate, endDate, ctx }) {
+  return await ctx.tx.db.ManualActivities.find({
+    classId,
+    date: {
+      $gte: startDate,
+      $lte: endDate,
+    },
+  }).select({
+    _id: 0,
+    id: 1,
+    name: 1,
+    description: 1,
+    date: 1,
+    classId: 1,
+  });
+}
+
+module.exports = listManualActivitiesForClassAndPeriod;

--- a/plugins/leemons-plugin-scores/backend/core/manualActivities/remove.js
+++ b/plugins/leemons-plugin-scores/backend/core/manualActivities/remove.js
@@ -1,0 +1,7 @@
+async function removeManualActivity({ id, ctx }) {
+  const { deletedCount } = await ctx.tx.db.ManualActivities.deleteOne({ id });
+
+  return deletedCount > 0;
+}
+
+module.exports = removeManualActivity;

--- a/plugins/leemons-plugin-scores/backend/core/manualActivities/scores/get.js
+++ b/plugins/leemons-plugin-scores/backend/core/manualActivities/scores/get.js
@@ -1,0 +1,17 @@
+async function getScores({ classId, ctx }) {
+  const scores = await ctx.tx.db.ManualActivityScores.find({ class: classId }).lean();
+
+  const response = {};
+
+  scores.forEach((score) => {
+    if (!response[score.activity]) {
+      response[score.activity] = {};
+    }
+
+    response[score.activity][score.user] = score;
+  });
+
+  return response;
+}
+
+module.exports = getScores;

--- a/plugins/leemons-plugin-scores/backend/core/manualActivities/scores/myScores.js
+++ b/plugins/leemons-plugin-scores/backend/core/manualActivities/scores/myScores.js
@@ -1,0 +1,10 @@
+const { keyBy } = require('lodash');
+
+async function getMyScores({ classId, ctx }) {
+  const user = ctx.meta.userSession.userAgents[0].id;
+  const scores = await ctx.tx.db.ManualActivityScores.find({ class: classId, user }).lean();
+
+  return keyBy(scores, 'activity');
+}
+
+module.exports = getMyScores;

--- a/plugins/leemons-plugin-scores/backend/core/manualActivities/scores/set.js
+++ b/plugins/leemons-plugin-scores/backend/core/manualActivities/scores/set.js
@@ -1,0 +1,36 @@
+const { validateManualActivityScore } = require('../validations/validateManualActivityScore');
+
+/**
+ *
+ * @param {object} props
+ * @param {object[]} props.scores
+ * @param {string} props.scores.user
+ * @param {string} props.scores.activity,
+ * @param {string} props.scores.grade
+ * @param {string} props.scores.class
+ * @param {string} props.ctx
+ */
+function setScores({ scores, ctx }) {
+  const userAgentId = ctx.meta.userSession.userAgents[0].id;
+
+  const scoresToSave = scores.map((score) => {
+    validateManualActivityScore({ ctx, manualActivityScore: score });
+
+    return {
+      ...score,
+      gradedBy: userAgentId,
+    };
+  });
+
+  return Promise.all(
+    scoresToSave.map((score) => {
+      return ctx.tx.db.ManualActivityScores.updateOne(
+        { user: score.user, activity: score.activity, class: score.class },
+        { $set: { grade: score.grade, gradedBy: userAgentId } },
+        { upsert: true }
+      );
+    })
+  );
+}
+
+module.exports = setScores;

--- a/plugins/leemons-plugin-scores/backend/core/manualActivities/upate.js
+++ b/plugins/leemons-plugin-scores/backend/core/manualActivities/upate.js
@@ -1,0 +1,14 @@
+const { validateManualActivity } = require('./validations/validateManualActivity');
+
+async function updateManualActivity({ id, manualActivity, ctx }) {
+  validateManualActivity({ manualActivity, ctx });
+
+  const { modifiedCount, matchedCount } = await ctx.tx.db.ManualActivities.updateOne(
+    { id },
+    manualActivity
+  );
+
+  return { modifiedCount, matchedCount };
+}
+
+module.exports = updateManualActivity;

--- a/plugins/leemons-plugin-scores/backend/core/manualActivities/validations/schema.js
+++ b/plugins/leemons-plugin-scores/backend/core/manualActivities/validations/schema.js
@@ -12,7 +12,7 @@ const manualActivitySchema = {
       type: 'string',
       format: 'date-time',
     },
-    type: {
+    role: {
       type: 'string',
       minLength: 1,
       // enum: ['task', 'test'], // This comes from assignables, so we don't check it, once assignables exposes it, we can check it
@@ -22,8 +22,31 @@ const manualActivitySchema = {
       format: 'lrn',
     },
   },
-  required: ['name', 'date', 'type', 'classId'],
+  required: ['name', 'date', 'role', 'classId'],
   additionalProperties: false,
 };
 
-module.exports = manualActivitySchema;
+const scoresSchema = {
+  type: 'object',
+  properties: {
+    user: {
+      type: 'string',
+      format: 'lrn',
+    },
+    activity: {
+      type: 'string',
+      format: 'lrn',
+    },
+    grade: {
+      type: 'number',
+    },
+    class: {
+      type: 'string',
+      format: 'lrn',
+    },
+  },
+  required: ['user', 'activity', 'grade', 'class'],
+  additionalProperties: false,
+};
+
+module.exports = { manualActivitySchema, scoresSchema };

--- a/plugins/leemons-plugin-scores/backend/core/manualActivities/validations/schema.js
+++ b/plugins/leemons-plugin-scores/backend/core/manualActivities/validations/schema.js
@@ -1,0 +1,27 @@
+const manualActivitySchema = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+    },
+    description: {
+      type: 'string',
+    },
+    date: {
+      type: 'string',
+      format: 'date-time',
+    },
+    type: {
+      type: 'string',
+      // enum: ['task', 'test'], // This comes from assignables, so we don't check it, once assignables exposes it, we can check it
+    },
+    classId: {
+      type: 'string',
+      format: 'lrn',
+    },
+  },
+  required: ['name', 'date', 'type', 'classId'],
+  additionalProperties: false,
+};
+
+module.exports = manualActivitySchema;

--- a/plugins/leemons-plugin-scores/backend/core/manualActivities/validations/schema.js
+++ b/plugins/leemons-plugin-scores/backend/core/manualActivities/validations/schema.js
@@ -3,6 +3,7 @@ const manualActivitySchema = {
   properties: {
     name: {
       type: 'string',
+      minLength: 1,
     },
     description: {
       type: 'string',
@@ -13,6 +14,7 @@ const manualActivitySchema = {
     },
     type: {
       type: 'string',
+      minLength: 1,
       // enum: ['task', 'test'], // This comes from assignables, so we don't check it, once assignables exposes it, we can check it
     },
     classId: {

--- a/plugins/leemons-plugin-scores/backend/core/manualActivities/validations/validateManualActivity.js
+++ b/plugins/leemons-plugin-scores/backend/core/manualActivities/validations/validateManualActivity.js
@@ -1,7 +1,7 @@
 const { LeemonsError } = require('@leemons/error');
 const { LeemonsValidator } = require('@leemons/validator');
 
-const manualActivitySchema = require('./schema');
+const { manualActivitySchema } = require('./schema');
 
 function validateManualActivity({ ctx, manualActivity }) {
   const validator = new LeemonsValidator(manualActivitySchema);

--- a/plugins/leemons-plugin-scores/backend/core/manualActivities/validations/validateManualActivity.js
+++ b/plugins/leemons-plugin-scores/backend/core/manualActivities/validations/validateManualActivity.js
@@ -1,0 +1,20 @@
+const { LeemonsError } = require('@leemons/error');
+const { LeemonsValidator } = require('@leemons/validator');
+
+const manualActivitySchema = require('./schema');
+
+function validateManualActivity({ ctx, manualActivity }) {
+  const validator = new LeemonsValidator(manualActivitySchema);
+
+  if (!validator.validate(manualActivity)) {
+    throw new LeemonsError(ctx, {
+      message: validator.errorMessage,
+      httpsStatusCode: 400,
+      customCode: 'INVALID_MANUAL_ACTIVITY',
+    });
+  }
+}
+
+module.exports = {
+  validateManualActivity,
+};

--- a/plugins/leemons-plugin-scores/backend/core/manualActivities/validations/validateManualActivity.js
+++ b/plugins/leemons-plugin-scores/backend/core/manualActivities/validations/validateManualActivity.js
@@ -9,7 +9,7 @@ function validateManualActivity({ ctx, manualActivity }) {
   if (!validator.validate(manualActivity)) {
     throw new LeemonsError(ctx, {
       message: validator.errorMessage,
-      httpsStatusCode: 400,
+      httpStatusCode: 400,
       customCode: 'INVALID_MANUAL_ACTIVITY',
     });
   }

--- a/plugins/leemons-plugin-scores/backend/core/manualActivities/validations/validateManualActivityScore.js
+++ b/plugins/leemons-plugin-scores/backend/core/manualActivities/validations/validateManualActivityScore.js
@@ -1,0 +1,20 @@
+const { LeemonsError } = require('@leemons/error');
+const { LeemonsValidator } = require('@leemons/validator');
+
+const { scoresSchema } = require('./schema');
+
+function validateManualActivityScore({ ctx, manualActivityScore }) {
+  const validator = new LeemonsValidator(scoresSchema);
+
+  if (!validator.validate(manualActivityScore)) {
+    throw new LeemonsError(ctx, {
+      message: validator.errorMessage,
+      httpStatusCode: 400,
+      customCode: 'INVALID_MANUAL_ACTIVITY_SCORE',
+    });
+  }
+}
+
+module.exports = {
+  validateManualActivityScore,
+};

--- a/plugins/leemons-plugin-scores/backend/i18n/en.js
+++ b/plugins/leemons-plugin-scores/backend/i18n/en.js
@@ -389,6 +389,10 @@ module.exports = {
       search: 'Search {type}...',
       showNonEvaluable: 'See non-evaluable',
       goToWeighting: 'Weights',
+      add: 'Add',
+      manualActivity: 'Graded activity',
+      manualActivityCreated: 'Graded activity created successfully',
+      manualActivityError: 'Error creating graded activity',
     },
     scoresTable: {
       students: 'Students',
@@ -446,5 +450,14 @@ module.exports = {
         description: 'We have not found results for your search.',
       },
     },
+  },
+  manualActivityDrawer: {
+    title: 'New graded activity',
+    config: 'Configuration',
+    date: { label: 'Date', error: 'The date is required' },
+    name: { label: 'Name', error: 'The name is required' },
+    description: { label: 'Description' },
+    cancel: 'Cancel',
+    save: 'Create activity',
   },
 };

--- a/plugins/leemons-plugin-scores/backend/i18n/en.js
+++ b/plugins/leemons-plugin-scores/backend/i18n/en.js
@@ -459,5 +459,13 @@ module.exports = {
     description: { label: 'Description' },
     cancel: 'Cancel',
     save: 'Create activity',
+
+    weightType: {
+      title: 'Weighting',
+      weightingBy: 'You are weighting by',
+      averages: 'this activity will count as part of the average',
+      modules: 'this activity will appear as a module',
+      roles: 'in which type would you like to add this activity?',
+    },
   },
 };

--- a/plugins/leemons-plugin-scores/backend/i18n/es.js
+++ b/plugins/leemons-plugin-scores/backend/i18n/es.js
@@ -461,5 +461,13 @@ module.exports = {
     description: { label: 'Descripción' },
     cancel: 'Cancelar',
     save: 'Crear actividad',
+
+    weightType: {
+      title: 'Ponderación',
+      weightingBy: 'Estás ponderando por',
+      averages: 'esta actividad pasará a contabilizarse en la media.',
+      modules: 'esta actividad aparecerá como Módulo.',
+      roles: '¿en qué tipo quieres incluir esta actividad?',
+    },
   },
 };

--- a/plugins/leemons-plugin-scores/backend/i18n/es.js
+++ b/plugins/leemons-plugin-scores/backend/i18n/es.js
@@ -390,6 +390,10 @@ module.exports = {
       search: 'Buscar {type}...',
       showNonEvaluable: 'Ver no calificables',
       goToWeighting: 'Ponderación',
+      add: 'Añadir',
+      manualActivity: 'Actividad evaluable',
+      manualActivityCreated: 'Actividad evaluable creada correctamente',
+      manualActivityError: 'Error creando actividad evaluable',
     },
     scoresTable: {
       students: 'Estudiantes',
@@ -448,5 +452,14 @@ module.exports = {
         description: 'No hemos encontrado resultados para tu búsqueda.',
       },
     },
+  },
+  manualActivityDrawer: {
+    title: 'Nueva actividad evaluable',
+    config: 'Configuración',
+    date: { label: 'Fecha', error: 'La fecha es obligatoria' },
+    name: { label: 'Nombre', error: 'El nombre es obligatorio' },
+    description: { label: 'Descripción' },
+    cancel: 'Cancelar',
+    save: 'Crear actividad',
   },
 };

--- a/plugins/leemons-plugin-scores/backend/models/index.js
+++ b/plugins/leemons-plugin-scores/backend/models/index.js
@@ -7,6 +7,7 @@ const models = {
   ...require('./scores'),
   ...require('./weights'),
   ...require('./manualActivities'),
+  ...require('./manualActivityScores'),
 };
 
 module.exports = {
@@ -17,6 +18,7 @@ module.exports = {
       Scores: models.scoresModel,
       Weights: models.weightsModel,
       ManualActivities: models.manualActivitiesModel,
+      ManualActivityScores: models.manualActivityScoresModel,
       KeyValue: getKeyValueModel({ modelName: 'v1::scores_KeyValue' }),
     };
   },

--- a/plugins/leemons-plugin-scores/backend/models/index.js
+++ b/plugins/leemons-plugin-scores/backend/models/index.js
@@ -6,6 +6,7 @@ const models = {
   ...require('./periods'),
   ...require('./scores'),
   ...require('./weights'),
+  ...require('./manualActivities'),
 };
 
 module.exports = {
@@ -15,6 +16,7 @@ module.exports = {
       Periods: models.periodsModel,
       Scores: models.scoresModel,
       Weights: models.weightsModel,
+      ManualActivities: models.manualActivitiesModel,
       KeyValue: getKeyValueModel({ modelName: 'v1::scores_KeyValue' }),
     };
   },

--- a/plugins/leemons-plugin-scores/backend/models/manualActivities.js
+++ b/plugins/leemons-plugin-scores/backend/models/manualActivities.js
@@ -1,0 +1,36 @@
+const { leemonsSchemaFields, mongoose, newModel } = require('@leemons/mongodb');
+
+const { PLUGIN_NAME, VERSION } = require('../config/constants');
+
+const schema = new mongoose.Schema({
+  ...leemonsSchemaFields,
+  name: {
+    type: String,
+    required: true,
+  },
+  description: {
+    type: String,
+  },
+  date: {
+    type: Date,
+    required: true,
+  },
+  type: {
+    type: String,
+    required: true,
+  },
+  classId: {
+    type: String,
+    required: true,
+  },
+});
+
+const manualActivitiesModel = newModel(
+  mongoose.connection,
+  `v${VERSION}::${PLUGIN_NAME}_ManualActivities`,
+  schema
+);
+
+module.exports = {
+  manualActivitiesModel,
+};

--- a/plugins/leemons-plugin-scores/backend/models/manualActivities.js
+++ b/plugins/leemons-plugin-scores/backend/models/manualActivities.js
@@ -15,7 +15,7 @@ const schema = new mongoose.Schema({
     type: Date,
     required: true,
   },
-  type: {
+  role: {
     type: String,
     required: true,
   },

--- a/plugins/leemons-plugin-scores/backend/models/manualActivityScores.js
+++ b/plugins/leemons-plugin-scores/backend/models/manualActivityScores.js
@@ -1,0 +1,44 @@
+const { mongoose, newModel, leemonsSchemaFields } = require('@leemons/mongodb');
+
+const schema = new mongoose.Schema(
+  {
+    ...leemonsSchemaFields,
+    activity: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    user: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    class: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    gradedBy: {
+      type: String,
+      required: true,
+    },
+    grade: {
+      type: Number,
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+    minimize: false,
+  }
+);
+
+schema.index({ activity: 1, user: 1, class: 1 }, { unique: true });
+
+const manualActivityScoresModel = newModel(
+  mongoose.connection,
+  'v1::scores_ManualActivityScores',
+  schema
+);
+
+module.exports = { manualActivityScoresModel };

--- a/plugins/leemons-plugin-scores/backend/services/manualActivities.service.js
+++ b/plugins/leemons-plugin-scores/backend/services/manualActivities.service.js
@@ -1,0 +1,23 @@
+const { LeemonsDeploymentManagerMixin } = require('@leemons/deployment-manager');
+const { LeemonsMiddlewaresMixin } = require('@leemons/middlewares');
+const { LeemonsMongoDBMixin } = require('@leemons/mongodb');
+
+const { PLUGIN_NAME, VERSION } = require('../config/constants');
+const { getServiceModels } = require('../models');
+
+const restActions = require('./rest/manualActivities.rest');
+
+module.exports = {
+  name: `${PLUGIN_NAME}.manualActivities`,
+  version: VERSION,
+  mixins: [
+    LeemonsMiddlewaresMixin(),
+    LeemonsMongoDBMixin({
+      models: getServiceModels(),
+    }),
+    LeemonsDeploymentManagerMixin(),
+  ],
+  actions: {
+    ...restActions,
+  },
+};

--- a/plugins/leemons-plugin-scores/backend/services/rest/manualActivities.rest.js
+++ b/plugins/leemons-plugin-scores/backend/services/rest/manualActivities.rest.js
@@ -34,8 +34,6 @@ const restActions = {
     },
     params: {
       classId: 'string',
-      startDate: 'string',
-      endDate: 'string',
     },
     async handler(ctx) {
       const { classId, startDate, endDate, search } = ctx.params;

--- a/plugins/leemons-plugin-scores/backend/services/rest/manualActivities.rest.js
+++ b/plugins/leemons-plugin-scores/backend/services/rest/manualActivities.rest.js
@@ -1,6 +1,10 @@
+const { LeemonsMiddlewareAuthenticated } = require('@leemons/middlewares');
+
 const addManualActivity = require('../../core/manualActivities/add');
 const listManualActivitiesForClassAndPeriod = require('../../core/manualActivities/list');
 const removeManualActivity = require('../../core/manualActivities/remove');
+const getScores = require('../../core/manualActivities/scores/get');
+const setScores = require('../../core/manualActivities/scores/set');
 const updateManualActivity = require('../../core/manualActivities/upate');
 
 const restActions = {
@@ -34,11 +38,12 @@ const restActions = {
       endDate: 'string',
     },
     async handler(ctx) {
-      const { classId, startDate, endDate } = ctx.params;
+      const { classId, startDate, endDate, search } = ctx.params;
       const manualActivities = await listManualActivitiesForClassAndPeriod({
         classId,
         startDate,
         endDate,
+        search,
         ctx,
       });
 
@@ -82,6 +87,44 @@ const restActions = {
 
       return {
         removed,
+        status: 200,
+      };
+    },
+  },
+
+  setScores: {
+    rest: {
+      method: 'PUT',
+      path: '/scores',
+    },
+    params: {
+      scores: 'array',
+    },
+    middlewares: [LeemonsMiddlewareAuthenticated()],
+    async handler(ctx) {
+      const { scores } = ctx.params;
+      const data = await setScores({ scores, ctx });
+
+      return {
+        data,
+        status: 200,
+      };
+    },
+  },
+  getScores: {
+    rest: {
+      method: 'GET',
+      path: '/scores/class/:classId',
+    },
+    params: {
+      classId: 'string',
+    },
+    async handler(ctx) {
+      const { classId } = ctx.params;
+      const data = await getScores({ classId, ctx });
+
+      return {
+        data,
         status: 200,
       };
     },

--- a/plugins/leemons-plugin-scores/backend/services/rest/manualActivities.rest.js
+++ b/plugins/leemons-plugin-scores/backend/services/rest/manualActivities.rest.js
@@ -1,0 +1,91 @@
+const addManualActivity = require('../../core/manualActivities/add');
+const listManualActivitiesForClassAndPeriod = require('../../core/manualActivities/list');
+const removeManualActivity = require('../../core/manualActivities/remove');
+const updateManualActivity = require('../../core/manualActivities/upate');
+
+const restActions = {
+  add: {
+    rest: {
+      method: 'POST',
+      path: '/',
+    },
+    params: {
+      manualActivity: 'object',
+    },
+    async handler(ctx) {
+      const { manualActivity } = ctx.params;
+
+      const id = await addManualActivity({ manualActivity, ctx });
+
+      return {
+        id,
+        status: 201,
+      };
+    },
+  },
+  listForClassAndPeriod: {
+    rest: {
+      method: 'GET',
+      path: '/class/:classId',
+    },
+    params: {
+      classId: 'string',
+      startDate: 'string',
+      endDate: 'string',
+    },
+    async handler(ctx) {
+      const { classId, startDate, endDate } = ctx.params;
+      const manualActivities = await listManualActivitiesForClassAndPeriod({
+        classId,
+        startDate,
+        endDate,
+        ctx,
+      });
+
+      return {
+        data: manualActivities,
+        status: 200,
+      };
+    },
+  },
+  update: {
+    rest: {
+      method: 'PUT',
+      path: '/:id',
+    },
+    params: {
+      id: 'string',
+      manualActivity: 'object',
+    },
+    async handler(ctx) {
+      const { id, manualActivity } = ctx.params;
+
+      const updated = await updateManualActivity({ id, manualActivity, ctx });
+
+      return {
+        ...updated,
+        status: 200,
+      };
+    },
+  },
+  remove: {
+    rest: {
+      method: 'DELETE',
+      path: '/:id',
+    },
+    params: {
+      id: 'string',
+    },
+    async handler(ctx) {
+      const { id } = ctx.params;
+      const removed = await removeManualActivity({ id, ctx });
+
+      return {
+        removed,
+        status: 200,
+      };
+    },
+  },
+};
+
+module.exports = restActions;

--- a/plugins/leemons-plugin-scores/backend/services/rest/manualActivities.rest.js
+++ b/plugins/leemons-plugin-scores/backend/services/rest/manualActivities.rest.js
@@ -4,6 +4,7 @@ const addManualActivity = require('../../core/manualActivities/add');
 const listManualActivitiesForClassAndPeriod = require('../../core/manualActivities/list');
 const removeManualActivity = require('../../core/manualActivities/remove');
 const getScores = require('../../core/manualActivities/scores/get');
+const getMyScores = require('../../core/manualActivities/scores/myScores');
 const setScores = require('../../core/manualActivities/scores/set');
 const updateManualActivity = require('../../core/manualActivities/upate');
 
@@ -120,6 +121,25 @@ const restActions = {
     async handler(ctx) {
       const { classId } = ctx.params;
       const data = await getScores({ classId, ctx });
+
+      return {
+        data,
+        status: 200,
+      };
+    },
+  },
+  getMyScores: {
+    rest: {
+      method: 'GET',
+      path: '/scores/class/:classId/user/me',
+    },
+    params: {
+      classId: 'string',
+    },
+    middlewares: [LeemonsMiddlewareAuthenticated()],
+    async handler(ctx) {
+      const { classId } = ctx.params;
+      const data = await getMyScores({ classId, ctx });
 
       return {
         data,

--- a/plugins/leemons-plugin-scores/backend/services/rest/manualActivities.rest.js
+++ b/plugins/leemons-plugin-scores/backend/services/rest/manualActivities.rest.js
@@ -17,6 +17,7 @@ const restActions = {
     params: {
       manualActivity: 'object',
     },
+    middlewares: [LeemonsMiddlewareAuthenticated()],
     async handler(ctx) {
       const { manualActivity } = ctx.params;
 
@@ -36,6 +37,7 @@ const restActions = {
     params: {
       classId: 'string',
     },
+    middlewares: [LeemonsMiddlewareAuthenticated()],
     async handler(ctx) {
       const { classId, startDate, endDate, search } = ctx.params;
       const manualActivities = await listManualActivitiesForClassAndPeriod({
@@ -61,6 +63,7 @@ const restActions = {
       id: 'string',
       manualActivity: 'object',
     },
+    middlewares: [LeemonsMiddlewareAuthenticated()],
     async handler(ctx) {
       const { id, manualActivity } = ctx.params;
 
@@ -80,6 +83,7 @@ const restActions = {
     params: {
       id: 'string',
     },
+    middlewares: [LeemonsMiddlewareAuthenticated()],
     async handler(ctx) {
       const { id } = ctx.params;
       const removed = await removeManualActivity({ id, ctx });
@@ -118,6 +122,7 @@ const restActions = {
     params: {
       classId: 'string',
     },
+    middlewares: [LeemonsMiddlewareAuthenticated()],
     async handler(ctx) {
       const { classId } = ctx.params;
       const data = await getScores({ classId, ctx });

--- a/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/ScoresTable/ScoresTable.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/ScoresTable/ScoresTable.js
@@ -14,6 +14,7 @@ import useTableData from './hooks/useTableData';
 import { ScoresBasicTable } from '@scores/components/Tables/ScoresBasicTable';
 import { prefixPN } from '@scores/helpers';
 import { useScoresMutation } from '@scores/requests/hooks/mutations';
+import { useSetManualActivityScoresMutation } from '@scores/requests/hooks/mutations/useSetManualActivityScoresMutation';
 import useEvaluationNotebookStore from '@scores/stores/evaluationNotebookStore';
 
 export default function ScoresTable({ program, class: klass, period, filters }) {
@@ -36,6 +37,7 @@ export default function ScoresTable({ program, class: klass, period, filters }) 
   const setTableData = useEvaluationNotebookStore((state) => state.setTableData);
   const { mutateAsync: assignationScoreMutate } = useStudentAssignationMutation();
   const { mutateAsync: customScoreMutate } = useScoresMutation();
+  const { mutateAsync: manualActivityScoreMutate } = useSetManualActivityScoresMutation();
 
   const { scales, usePercentage, activities, studentsData, isLoading } = useTableData({
     program,
@@ -88,6 +90,7 @@ export default function ScoresTable({ program, class: klass, period, filters }) 
         onDataChange={onDataChange({
           assignationScoreMutate,
           customScoreMutate,
+          manualActivityScoreMutate,
           scales,
           students: studentsData,
           activities,

--- a/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/ScoresTable/helpers/onDataChange.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/ScoresTable/helpers/onDataChange.js
@@ -3,6 +3,7 @@ import { printErrorMessage, printSuccessMessage } from './printMessages';
 export default function onDataChange({
   assignationScoreMutate,
   customScoreMutate,
+  manualActivityScoreMutate,
   scales,
   students,
   activities,
@@ -61,20 +62,41 @@ export default function onDataChange({
         );
     }
 
-    return assignationScoreMutate({
-      instance: value.columnId,
-      student: value.rowId,
-      grades: [
-        {
-          type: 'main',
-          grade: grade.number,
-          subject: klass.subject.id,
-        },
-      ],
-    })
-      .then(() => printSuccessMessage({ labels, student, activity: activity.name, score: grade }))
-      .catch((e) =>
-        printErrorMessage({ labels, student, activity: activity.name, score: grade, error: e })
-      );
+    if (activity.source === 'manualActivities') {
+      return manualActivityScoreMutate({
+        scores: [
+          {
+            user: student.id,
+            activity: activity.id,
+            grade: grade.number,
+            class: klass.id,
+          },
+        ],
+      })
+        .then(() => printSuccessMessage({ labels, student, activity: activity.name, score: grade }))
+        .catch((e) =>
+          printErrorMessage({ labels, student, activity: activity.name, score: grade, error: e })
+        );
+    }
+
+    if (activity.source === 'assignables') {
+      return assignationScoreMutate({
+        instance: value.columnId,
+        student: value.rowId,
+        grades: [
+          {
+            type: 'main',
+            grade: grade.number,
+            subject: klass.subject.id,
+          },
+        ],
+      })
+        .then(() => printSuccessMessage({ labels, student, activity: activity.name, score: grade }))
+        .catch((e) =>
+          printErrorMessage({ labels, student, activity: activity.name, score: grade, error: e })
+        );
+    }
+
+    throw new Error('Invalid activity source');
   };
 }

--- a/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/ScoresTable/helpers/printMessages.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/ScoresTable/helpers/printMessages.js
@@ -14,6 +14,7 @@ export function printErrorMessage({ labels, student, activity, score, error }) {
       ?.replace('{{student}}', `${student.name} ${student.surname}`)
       ?.replace('{{activity}}', activity)
       ?.replace('{{score}}', score.letter || score.number)
-      ?.replace('{{error}}', error.message || error.error)
+      ?.replace('{{error}}', error.message || error.error),
+    error.message
   );
 }

--- a/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/ScoresTable/helpers/printMessages.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/ScoresTable/helpers/printMessages.js
@@ -5,7 +5,7 @@ export function printSuccessMessage({ labels, student, activity, score }) {
     labels?.updatedSuccess
       ?.replace('{{student}}', `${student.name} ${student.surname}`)
       ?.replace('{{activity}}', activity)
-      ?.replace('{{score}}', score.letter || score.number)
+      ?.replace('{{score}}', score?.letter || score?.number)
   );
 }
 export function printErrorMessage({ labels, student, activity, score, error }) {
@@ -13,7 +13,7 @@ export function printErrorMessage({ labels, student, activity, score, error }) {
     labels?.updatedError
       ?.replace('{{student}}', `${student.name} ${student.surname}`)
       ?.replace('{{activity}}', activity)
-      ?.replace('{{score}}', score.letter || score.number)
+      ?.replace('{{score}}', score?.letter || score?.number)
       ?.replace('{{error}}', error.message || error.error),
     error.message
   );

--- a/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/ScoresTable/hooks/useActivities.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/ScoresTable/hooks/useActivities.js
@@ -70,6 +70,8 @@ export default function useActivities({
         allowChange: instance.metadata.evaluationType !== 'auto',
         type: instance.gradable ? 'evaluable' : 'non-evaluable',
 
+        source: 'assignables',
+
         role: instance.assignable.role,
         roleIcon: instance.assignable.roleDetails.icon,
         isEvaluable: instance.gradable,

--- a/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/ScoresTable/hooks/useActivities.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/ScoresTable/hooks/useActivities.js
@@ -1,11 +1,10 @@
 import { useMemo } from 'react';
 
-import { map, without } from 'lodash';
-import dayjs from 'dayjs';
-
-import useSearchAssignableInstances from '@assignables/requests/hooks/queries/useSearchAssignableInstancesQuery';
 import useInstances from '@assignables/requests/hooks/queries/useInstances';
 import useRolesList from '@assignables/requests/hooks/queries/useRolesList';
+import useSearchAssignableInstances from '@assignables/requests/hooks/queries/useSearchAssignableInstancesQuery';
+import dayjs from 'dayjs';
+import { map, without } from 'lodash';
 
 export function getNextDayFirstMillisecond(date) {
   return dayjs(date)
@@ -50,7 +49,8 @@ export default function useActivities({
       programs: program,
       classes: klass?.id,
 
-      isEvaluable: !showNonEvaluable,
+      isEvaluable: true,
+      calificableOnly: !showNonEvaluable,
     },
     select: (result) => result.items,
   });
@@ -68,11 +68,11 @@ export default function useActivities({
         deadline: instance.alwaysAvailable ? null : instance.dates.deadline,
         expandable: false,
         allowChange: instance.metadata.evaluationType !== 'auto',
-        type: instance.requiresScoring ? 'evaluable' : 'non-evaluable',
+        type: instance.gradable ? 'evaluable' : 'non-evaluable',
 
         role: instance.assignable.role,
         roleIcon: instance.assignable.roleDetails.icon,
-        isEvaluable: instance.requiresScoring,
+        isEvaluable: instance.gradable,
         students: instance.students,
 
         instance,

--- a/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/ScoresTable/hooks/useManualActivitesForNotebook.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/ScoresTable/hooks/useManualActivitesForNotebook.js
@@ -1,0 +1,84 @@
+import { useMemo } from 'react';
+
+import useClassStudents from '@academic-portfolio/hooks/queries/useClassStudents';
+import useRolesList from '@assignables/requests/hooks/queries/useRolesList';
+import { keyBy } from 'lodash';
+
+import { useManualActivities } from '@scores/requests/hooks/queries/useManualActivities';
+import { useManualActivitiesScores } from '@scores/requests/hooks/queries/useManualActivitiesScores';
+
+function parseActivity({ activity, roles, students, subject, scores }) {
+  return {
+    id: activity.id,
+    name: activity.name,
+    deadline: activity.date,
+    role: activity.role,
+    roleIcon: roles[activity.role]?.icon,
+
+    allowChange: true,
+    expandable: false,
+    type: 'evaluable',
+    isEvaluable: true,
+
+    instance: null,
+    students: students.map((student) => ({
+      id: `${activity.id}-${student}`,
+      user: student,
+
+      isSubmitted: true,
+
+      timestamps: {
+        end: new Date(),
+      },
+
+      score: scores[activity.id]?.[student]?.grade,
+
+      grades: scores[activity.id]?.[student]
+        ? [
+            {
+              type: 'main',
+              subject,
+              grade: scores[activity.id]?.[student]?.grade,
+            },
+          ]
+        : [],
+    })),
+
+    source: 'manualActivities',
+  };
+}
+
+export function useManualActivitesForNotebook({ klass, period, filters }) {
+  const hasAllData = !!klass?.id && !!period?.startDate && !!period?.endDate;
+  const { data: roles } = useRolesList({ details: true, select: (data) => keyBy(data, 'name') });
+
+  const { data: classStudents } = useClassStudents({ classId: klass?.id });
+
+  const { data: manualActivities, isLoading: manualActivitiesLoading } = useManualActivities({
+    search: filters?.searchType === 'activity' && filters?.search ? filters?.search : undefined,
+    classId: klass?.id,
+    startDate: period?.startDate,
+    endDate: period?.endDate,
+    enabled: hasAllData,
+  });
+  const { data: manualActivitiesScores } = useManualActivitiesScores({
+    classId: klass?.id,
+    enabled: hasAllData,
+  });
+
+  const parsedActivities = useMemo(
+    () =>
+      manualActivities?.map((activity) =>
+        parseActivity({
+          activity,
+          roles,
+          students: classStudents ?? [],
+          subject: filters?.subject,
+          scores: manualActivitiesScores,
+        })
+      ),
+    [manualActivities, roles, classStudents, filters?.subject, manualActivitiesScores]
+  );
+
+  return { manualActivities: parsedActivities ?? [], isLoading: manualActivitiesLoading };
+}

--- a/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/ManualActivityDrawer/ManualActivityDrawer.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/ManualActivityDrawer/ManualActivityDrawer.js
@@ -81,7 +81,7 @@ export function ManualActivityDrawer({ isOpen, onClose: _onClose, onSubmit, minD
             name="description"
             render={({ field }) => (
               <Box sx={{ width: '75%' }}>
-                <Textarea {...field} label={t('description')} />
+                <Textarea {...field} label={t('description.label')} />
               </Box>
             )}
           />

--- a/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/ManualActivityDrawer/ManualActivityDrawer.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/ManualActivityDrawer/ManualActivityDrawer.js
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+
+import {
+  Drawer,
+  Button,
+  ContextContainer,
+  DatePicker,
+  TextInput,
+  Textarea,
+  Box,
+} from '@bubbles-ui/components';
+import useTranslateLoader from '@multilanguage/useTranslateLoader';
+import PropTypes from 'prop-types';
+
+import { prefixPN } from '@scores/helpers';
+
+const defaultValues = { date: null, name: '', description: '' };
+
+export function ManualActivityDrawer({ isOpen, onClose: _onClose, onSubmit, minDate, maxDate }) {
+  const [t] = useTranslateLoader(prefixPN('manualActivityDrawer'));
+  const form = useForm({ defaultValues });
+  const [isLoading, setIsLoading] = useState(false);
+
+  const onClose = () => {
+    _onClose();
+
+    form.reset(defaultValues);
+  };
+
+  const handleSubmit = form.handleSubmit((data) => {
+    setIsLoading(true);
+    onSubmit(data)
+      .then(onClose)
+      .catch(() => {})
+      .finally(() => setIsLoading(false));
+  });
+
+  return (
+    <Drawer opened={isOpen} onClose={onClose}>
+      <Drawer.Header title={t('title')} />
+
+      <Drawer.Content>
+        <ContextContainer title={t('config')}>
+          <Controller
+            control={form.control}
+            name="date"
+            rules={{ required: t('date.error') }}
+            render={({ field, fieldState }) => (
+              <Box sx={{ width: '50%' }}>
+                <DatePicker
+                  {...field}
+                  label={t('date.label')}
+                  error={fieldState.error?.message}
+                  required
+                  minDate={minDate}
+                  maxDate={maxDate}
+                />
+              </Box>
+            )}
+          />
+
+          <Controller
+            control={form.control}
+            name="name"
+            rules={{ required: t('name.error') }}
+            render={({ field, fieldState }) => (
+              <Box sx={{ width: '50%' }}>
+                <TextInput
+                  {...field}
+                  label={t('name.label')}
+                  error={fieldState.error?.message}
+                  required
+                />
+              </Box>
+            )}
+          />
+
+          <Controller
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <Box sx={{ width: '75%' }}>
+                <Textarea {...field} label={t('description')} />
+              </Box>
+            )}
+          />
+        </ContextContainer>
+
+        <ContextContainer title={t('weight')}></ContextContainer>
+      </Drawer.Content>
+
+      <Drawer.Footer>
+        <Drawer.Footer.LeftActions>
+          <Button variant="link" onClick={onClose}>
+            {t('cancel')}
+          </Button>
+        </Drawer.Footer.LeftActions>
+        <Drawer.Footer.RightActions>
+          <Button onClick={handleSubmit} loading={isLoading}>
+            {t('save')}
+          </Button>
+        </Drawer.Footer.RightActions>
+      </Drawer.Footer>
+    </Drawer>
+  );
+}
+
+ManualActivityDrawer.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  minDate: PropTypes.instanceOf(Date),
+  maxDate: PropTypes.instanceOf(Date),
+};

--- a/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/ManualActivityDrawer/index.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/ManualActivityDrawer/index.js
@@ -1,0 +1,1 @@
+export * from './ManualActivityDrawer';

--- a/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/NotebookFilters/NotebookFilters.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/NotebookFilters/NotebookFilters.js
@@ -74,6 +74,7 @@ export default function NotebookFilters({ filters, onChange, value }) {
         onClose={() => setWeightDrawerIsOpen(false)}
       />
       <ManualActivityDrawer
+        classId={filters?.class?.id}
         isOpen={manualActivityDrawerIsOpen}
         onClose={() => setManualActivityDrawerIsOpen(false)}
         minDate={new Date(filters?.period?.startDate)}
@@ -82,7 +83,6 @@ export default function NotebookFilters({ filters, onChange, value }) {
           try {
             await createManualActivity({
               ...data,
-              role: 'task',
               classId: filters.class.id,
             });
             addSuccessAlert(t('manualActivityCreated'));
@@ -93,7 +93,7 @@ export default function NotebookFilters({ filters, onChange, value }) {
         }}
       />
 
-      <Stack direction="row" justifyContent="space-between" alignItems="baseline">
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
         <Stack direction="row" spacing={4}>
           <Controller
             name="searchType"
@@ -113,7 +113,7 @@ export default function NotebookFilters({ filters, onChange, value }) {
             )}
           />
         </Stack>
-        <Stack direction="row" spacing={4} alignItems="baseline">
+        <Stack direction="row" spacing={4} alignItems="center">
           <Controller
             name="showNonEvaluable"
             control={form.control}

--- a/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/NotebookFilters/NotebookFilters.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/NotebookFilters/NotebookFilters.js
@@ -73,6 +73,8 @@ export default function NotebookFilters({ filters, onChange, value }) {
       <ManualActivityDrawer
         isOpen={manualActivityDrawerIsOpen}
         onClose={() => setManualActivityDrawerIsOpen(false)}
+        minDate={new Date(filters?.period?.startDate)}
+        maxDate={new Date(filters?.period?.endDate)}
         onSubmit={async (data) => {
           try {
             await createManualActivity({

--- a/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/NotebookFilters/NotebookFilters.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/NotebookFilters/NotebookFilters.js
@@ -24,6 +24,7 @@ import useSearchTypes from './hooks/useSearchTypes';
 import { WeightConfigDrawer } from '@scores/components/Weights/components/WeightConfigDrawer';
 import { prefixPN } from '@scores/helpers';
 import { useCreateManualActivityMutation } from '@scores/requests/hooks/mutations/useCreateManualActivityMutation';
+import useEvaluationNotebookStore from '@scores/stores/evaluationNotebookStore';
 
 export default function NotebookFilters({ filters, onChange, value }) {
   const [t] = useTranslateLoader(prefixPN('evaluationNotebook.filters'));
@@ -32,6 +33,8 @@ export default function NotebookFilters({ filters, onChange, value }) {
   const deploymentConfig = useDeploymentConfig({ pluginName: 'scores', ignoreVersion: true });
   const hideWeighting = deploymentConfig?.deny?.menu?.includes('scores.weights');
   const { mutateAsync: createManualActivity } = useCreateManualActivityMutation();
+
+  const isPeriodPublished = useEvaluationNotebookStore((state) => state.isPeriodPublished);
 
   const form = useForm({
     defaultValues: {
@@ -135,6 +138,7 @@ export default function NotebookFilters({ filters, onChange, value }) {
               {
                 label: t('manualActivity'),
                 onClick: () => setManualActivityDrawerIsOpen(true),
+                disabled: isPeriodPublished,
               },
             ]}
           >

--- a/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/NotebookFilters/NotebookFilters.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/NotebookFilters/NotebookFilters.js
@@ -77,7 +77,7 @@ export default function NotebookFilters({ filters, onChange, value }) {
           try {
             await createManualActivity({
               ...data,
-              type: 'task',
+              role: 'task',
               classId: filters.class.id,
             });
             addSuccessAlert(t('manualActivityCreated'));

--- a/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/PageFooter/PageFooter.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/PageFooter/PageFooter.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Button } from '@bubbles-ui/components';
 import { DownloadIcon } from '@bubbles-ui/icons/solid';
@@ -14,19 +14,27 @@ import useEvaluationNotebookStore from '@scores/stores/evaluationNotebookStore';
 export default function Footer({ isCustom }) {
   const [t] = useTranslateLoader(prefixPN('evaluationNotebook.footer'));
   const tableData = useEvaluationNotebookStore((state) => state.tableData);
+  const isPeriodPublished = useEvaluationNotebookStore((state) => state.isPeriodPublished);
+  const setIsPeriodPublished = useEvaluationNotebookStore((state) => state.setIsPeriodPublished);
 
   const [isLoading, setIsLoading] = useState(false);
 
   const downloadScoreReport = useDownloadScoreReport();
   const onCloseEvaluation = useCloseEvaluation();
 
+  useEffect(() => {
+    const isPublished = tableData?.activitiesData?.value?.every(
+      (student) => !student.allowCustomChange
+    );
+
+    if (isPublished !== isPeriodPublished) {
+      setIsPeriodPublished(isPublished);
+    }
+  }, [tableData?.activitiesData?.value, isPeriodPublished, setIsPeriodPublished]);
+
   if (!tableData?.activitiesData?.activities?.length || !tableData?.activitiesData?.value?.length) {
     return null;
   }
-
-  const isPeriodPublished = tableData.activitiesData.value.every(
-    (student) => !student.allowCustomChange
-  );
 
   return (
     <>

--- a/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/Filters/hooks/useStudentPeriods.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/Filters/hooks/useStudentPeriods.js
@@ -1,12 +1,12 @@
 import { useWatch } from 'react-hook-form';
 
 import useProgramClasses from '@academic-portfolio/hooks/useProgramClasses';
+
 import { useMatchingAcademicCalendarPeriods } from '@scores/components/__DEPRECATED__/FinalNotebook/FinalScores';
 import useAcademicCalendarDates from '@scores/components/__DEPRECATED__/ScoresPage/Filters/hooks/useAcademicCalendarDates';
-import { getSessionConfig } from '@users/session';
 
 export default function useStudentPeriods({ control }) {
-  const { program } = getSessionConfig();
+  const program = useWatch({ name: 'program', control });
   const course = useWatch({ name: 'course', control });
 
   const { data: classesData, isLoading: classesLoading } = useProgramClasses(program, {

--- a/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/PageFooter/hooks/useDownloadStudentReport.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/PageFooter/hooks/useDownloadStudentReport.js
@@ -1,10 +1,10 @@
-import { isNil, keyBy } from 'lodash';
-
 import useProgramEvaluationSystems from '@grades/hooks/queries/useProgramEvaluationSystem';
-import useDownloadScoreReport from '@scores/components/EvaluationNotebook/components/PageFooter/hooks/useDownloadScoreReport';
-import useMyScoresStore from '@scores/stores/myScoresStore';
 import { useUserAgentsInfo } from '@users/hooks';
 import useUserAgents from '@users/hooks/useUserAgents';
+import { isNil, keyBy } from 'lodash';
+
+import useDownloadScoreReport from '@scores/components/EvaluationNotebook/components/PageFooter/hooks/useDownloadScoreReport';
+import useMyScoresStore from '@scores/stores/myScoresStore';
 
 export default function useDownloadStudentReport() {
   const columns = useMyScoresStore((store) => store.columns);
@@ -43,7 +43,7 @@ export default function useDownloadStudentReport() {
               instance,
               name: instance.assignable.asset.name,
               role: instance.assignable.asset.role,
-              type: instance.requiresScoring ? 'evaluable' : 'non-evaluable',
+              type: instance.gradable ? 'evaluable' : 'non-evaluable',
               weight: activity.weight,
             };
           }),

--- a/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/SubjectsScoreList/components/SubjectScoreColumn/components/ActivityScoreDisplay/ActivityScoreDisplay.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/SubjectsScoreList/components/SubjectScoreColumn/components/ActivityScoreDisplay/ActivityScoreDisplay.js
@@ -1,14 +1,14 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-
 import { Link } from 'react-router-dom';
-import { Badge, Box, Stack, Text, TextClamp } from '@bubbles-ui/components';
 
 import useRolesLocalizations from '@assignables/hooks/useRolesLocalizations';
-import getNearestScale from '@scorm/helpers/getNearestScale';
+import { Badge, Box, Stack, Text, TextClamp } from '@bubbles-ui/components';
 import useTranslateLoader from '@multilanguage/useTranslateLoader';
-import { prefixPN } from '@scores/helpers';
+import getNearestScale from '@scorm/helpers/getNearestScale';
+import PropTypes from 'prop-types';
+
 import useActivityScoreDisplayStyles from './ActivityScoreDisplay.styles';
+
+import { prefixPN } from '@scores/helpers';
 
 export default function ActivityScoreDisplay({ activity = {}, evaluationSystem }) {
   const [t] = useTranslateLoader(prefixPN('myScores'));
@@ -38,7 +38,7 @@ export default function ActivityScoreDisplay({ activity = {}, evaluationSystem }
           <Text transform="uppercase" className={classes.role}>
             {roleLocalizations[role]?.singular}
           </Text>
-          {!activity.instance.requiresScoring && (
+          {!activity.instance.gradable && (
             <Text className={classes.nonScoringActivity} color="warning">
               {t('noEvaluable')}
             </Text>
@@ -54,7 +54,7 @@ export default function ActivityScoreDisplay({ activity = {}, evaluationSystem }
       */}
       <Stack direction="column" spacing={1} className={classes.rightSide} alignItems="center">
         <Box className={classes.badge}>
-          {!activity.hasNoWeight && activity.instance.requiresScoring && (
+          {!activity.hasNoWeight && activity.instance.gradable && (
             <Badge closable={false} color="stroke">
               {parseFloat((activity.weight * 100).toFixed(2))}%
             </Badge>
@@ -83,7 +83,7 @@ export default function ActivityScoreDisplay({ activity = {}, evaluationSystem }
 ActivityScoreDisplay.propTypes = {
   activity: PropTypes.shape({
     instance: PropTypes.shape({
-      requiresScoring: PropTypes.bool,
+      gradable: PropTypes.bool,
       id: PropTypes.string,
     }),
     assignable: PropTypes.shape({

--- a/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/SubjectsScoreList/components/SubjectScoreColumn/components/ActivityScoreTotal/ActivityScoreTotal.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/SubjectsScoreList/components/SubjectScoreColumn/components/ActivityScoreTotal/ActivityScoreTotal.js
@@ -1,15 +1,16 @@
-import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
+import { useEffect } from 'react';
 
 import { Stack, Text } from '@bubbles-ui/components';
-import { isNil, sortBy } from 'lodash';
-
-import getNearestScale from '@scorm/helpers/getNearestScale';
 import useTranslateLoader from '@multilanguage/useTranslateLoader';
+import getNearestScale from '@scorm/helpers/getNearestScale';
+import { isNil, sortBy } from 'lodash';
+import PropTypes from 'prop-types';
+
+import useActivityScoreTotalStyles from './ActivityScoreTotal.style';
+
 import { prefixPN } from '@scores/helpers';
 import { useScores } from '@scores/requests/hooks/queries';
 import useMyScoresStore from '@scores/stores/myScoresStore';
-import useActivityScoreTotalStyles from './ActivityScoreTotal.style';
 
 export default function ActivityScoreTotal({ class: klass, period, activities, evaluationSystem }) {
   const setFinalScore = useMyScoresStore((state) => state.setFinalScore);
@@ -17,7 +18,7 @@ export default function ActivityScoreTotal({ class: klass, period, activities, e
   const [t] = useTranslateLoader(prefixPN('myScores'));
   const hasNonEvaluatedActivities = activities.some(
     (activity) =>
-      activity.instance.requiresScoring &&
+      activity.instance.gradable &&
       isNil(activity.mainGrade) &&
       activity.instance.metadata?.evaluationType !== 'auto'
   );
@@ -82,7 +83,7 @@ ActivityScoreTotal.propTypes = {
   activities: PropTypes.arrayOf(
     PropTypes.shape({
       instance: PropTypes.shape({
-        requiresScoring: PropTypes.bool,
+        gradable: PropTypes.bool,
         assignable: PropTypes.shape({
           asset: PropTypes.shape({
             name: PropTypes.string,

--- a/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/SubjectsScoreList/components/SubjectScoreColumn/hooks/useActivities.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/SubjectsScoreList/components/SubjectScoreColumn/hooks/useActivities.js
@@ -5,6 +5,8 @@ import useRolesList from '@assignables/requests/hooks/queries/useRolesList';
 import useSearchAssignableInstances from '@assignables/requests/hooks/queries/useSearchAssignableInstancesQuery';
 import { without } from 'lodash';
 
+import { useManualActivitiesForStudent } from './useManualActivitiesForStudent';
+
 import {
   getNextDayFirstMillisecond,
   getPreviousDayLastMillisecond,
@@ -33,12 +35,20 @@ export default function useActivities({ class: klass, period, showNonEvaluable, 
     select: (result) => result.items,
   });
 
-  const { data: activities, isLoading: activitiesLoading } = useAssignationsByProfile(
+  const { data: assignations, isLoading: activitiesLoading } = useAssignationsByProfile(
     activitiesIds,
     {
       enabled: !!activitiesIds?.length,
     }
   );
+
+  const { manualActivities, isLoading: manualActivitiesLoading } = useManualActivitiesForStudent({
+    klass,
+    period,
+    search,
+  });
+
+  const activities = (assignations ?? []).concat(manualActivities ?? []);
 
   const activitiesWithGrades = useMemo(
     () =>
@@ -57,6 +67,9 @@ export default function useActivities({ class: klass, period, showNonEvaluable, 
 
   return {
     activities: activitiesWithGrades ?? [],
-    isLoading: activitiesIdsLoading || (activitiesLoading && activitiesIds?.length),
+    isLoading:
+      activitiesIdsLoading ||
+      manualActivitiesLoading ||
+      (activitiesLoading && activitiesIds?.length),
   };
 }

--- a/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/SubjectsScoreList/components/SubjectScoreColumn/hooks/useActivities.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/SubjectsScoreList/components/SubjectScoreColumn/hooks/useActivities.js
@@ -1,14 +1,14 @@
 import { useMemo } from 'react';
 
+import useAssignationsByProfile from '@assignables/hooks/assignations/useAssignationsByProfile';
+import useRolesList from '@assignables/requests/hooks/queries/useRolesList';
+import useSearchAssignableInstances from '@assignables/requests/hooks/queries/useSearchAssignableInstancesQuery';
 import { without } from 'lodash';
 
-import useSearchAssignableInstances from '@assignables/requests/hooks/queries/useSearchAssignableInstancesQuery';
 import {
   getNextDayFirstMillisecond,
   getPreviousDayLastMillisecond,
 } from '@scores/components/EvaluationNotebook/ScoresTable/hooks/useActivities';
-import useRolesList from '@assignables/requests/hooks/queries/useRolesList';
-import useAssignationsByProfile from '@assignables/hooks/assignations/useAssignationsByProfile';
 
 export default function useActivities({ class: klass, period, showNonEvaluable, weights, search }) {
   const { data: roles } = useRolesList({
@@ -27,7 +27,8 @@ export default function useActivities({ class: klass, period, showNonEvaluable, 
       role: weights?.type === 'modules' ? 'learningpaths.module' : roles,
       classes: klass?.id,
 
-      isEvaluable: !showNonEvaluable,
+      isEvaluable: true,
+      calificableOnly: !showNonEvaluable,
     },
     select: (result) => result.items,
   });

--- a/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/SubjectsScoreList/components/SubjectScoreColumn/hooks/useActivitiesWithWeights.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/SubjectsScoreList/components/SubjectScoreColumn/hooks/useActivitiesWithWeights.js
@@ -1,10 +1,11 @@
 import { filter, keyBy, groupBy } from 'lodash';
 
-import getApplySameValueWeightForUnlocked from '@scores/components/EvaluationNotebook/ScoresTable/helpers/getApplySameValueWeightForUnlocked';
 import useActivities from './useActivities';
 
+import getApplySameValueWeightForUnlocked from '@scores/components/EvaluationNotebook/ScoresTable/helpers/getApplySameValueWeightForUnlocked';
+
 function getActivitiesWeightsByModules({ weights, activities }) {
-  const evaluableActivities = filter(activities, 'instance.requiresScoring');
+  const evaluableActivities = filter(activities, 'instance.gradable');
 
   const { applySameValue } = weights;
   const weightsPerModuleId = keyBy(weights.weights, 'id');
@@ -15,7 +16,7 @@ function getActivitiesWeightsByModules({ weights, activities }) {
 
     let weightValue = weight?.weight;
 
-    if (!weight?.isLocked && applySameValue && activity?.instance?.requiresScoring) {
+    if (!weight?.isLocked && applySameValue && activity?.instance?.gradable) {
       weightValue = getApplySameValueWeightForUnlocked(weights, modulesCount);
     }
 
@@ -28,7 +29,7 @@ function getActivitiesWeightsByModules({ weights, activities }) {
 }
 
 function getActivitiesWeightsByRoles({ weights, activities }) {
-  const evaluableActivities = filter(activities, 'instance.requiresScoring');
+  const evaluableActivities = filter(activities, 'instance.gradable');
 
   const { applySameValue } = weights;
   const weightsPerType = keyBy(weights.weights, 'id');
@@ -41,7 +42,7 @@ function getActivitiesWeightsByRoles({ weights, activities }) {
     const roleWeight = weightsPerType[role];
     let weightValue = roleWeight?.weight;
 
-    if (!roleWeight?.isLocked && applySameValue && activity?.instance?.requiresScoring) {
+    if (!roleWeight?.isLocked && applySameValue && activity?.instance?.gradable) {
       weightValue = getApplySameValueWeightForUnlocked(weights, rolesCount);
     }
 
@@ -55,13 +56,13 @@ function getActivitiesWeightsByRoles({ weights, activities }) {
 }
 
 function getActivitiesWeightsWithSameValue({ activities }) {
-  const evaluableActivities = filter(activities, 'instance.requiresScoring');
+  const evaluableActivities = filter(activities, 'instance.gradable');
   const activitiesCount = evaluableActivities?.length;
   const weightPerActivity = Number((1 / activitiesCount).toFixed(4));
 
   return activities.map((activity) => ({
     ...activity,
-    weight: (activity?.instance?.requiresScoring ? weightPerActivity : 0) ?? 0,
+    weight: (activity?.instance?.gradable ? weightPerActivity : 0) ?? 0,
   }));
 }
 

--- a/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/SubjectsScoreList/components/SubjectScoreColumn/hooks/useManualActivitiesForStudent.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/SubjectsScoreList/components/SubjectScoreColumn/hooks/useManualActivitiesForStudent.js
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+
+import useRolesList from '@assignables/requests/hooks/queries/useRolesList';
+import { getCookieToken } from '@users/session';
+import { keyBy } from 'lodash';
+
+import { useManualActivities } from '@scores/requests/hooks/queries/useManualActivities';
+
+function parseActivity({ activity, user, roles }) {
+  return {
+    id: `${activity.id}-${user}`,
+    grades: [],
+    isSubmitted: true,
+    user,
+    instance: {
+      dates: {
+        deadline: activity.date,
+      },
+      assignable: {
+        role: activity.role,
+        roleDetails: roles?.[activity.role] ?? {},
+        asset: {
+          name: activity.name,
+        },
+      },
+      gradable: true,
+    },
+    source: 'manualActivities',
+  };
+}
+
+export function useManualActivitiesForStudent({ klass, period, search }) {
+  const hasAllData = !!klass?.id && !!period?.startDate && !!period?.endDate;
+
+  const token = getCookieToken(true);
+  const user = token.centers[0].userAgentId;
+
+  const { data: manualActivities, isLoading: manualActivitiesLoading } = useManualActivities({
+    search: search ?? undefined,
+    classId: klass?.id,
+    startDate: period?.startDate,
+    endDate: period?.endDate,
+    enabled: hasAllData,
+  });
+
+  const { data: roles } = useRolesList({ details: true, select: (data) => keyBy(data, 'name') });
+
+  const parsedActivities = useMemo(
+    () =>
+      manualActivities?.map((activity) =>
+        parseActivity({
+          activity,
+          user,
+          roles,
+          // students: classStudents ?? [],
+          // subject: filters?.subject,
+          // scores: manualActivitiesScores,
+        })
+      ),
+    [manualActivities, user, roles]
+  );
+
+  return {
+    manualActivities: parsedActivities ?? [],
+    isLoading: manualActivitiesLoading,
+  };
+}

--- a/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/SubjectsScoreList/components/SubjectScoreColumn/hooks/useManualActivitiesForStudent.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/SubjectsScoreList/components/SubjectScoreColumn/hooks/useManualActivitiesForStudent.js
@@ -5,11 +5,21 @@ import { getCookieToken } from '@users/session';
 import { keyBy } from 'lodash';
 
 import { useManualActivities } from '@scores/requests/hooks/queries/useManualActivities';
+import { useMyManualActivitiesScores } from '@scores/requests/hooks/queries/useMyManualActivitiesScores';
 
-function parseActivity({ activity, user, roles }) {
+function parseActivity({ activity, user, roles, subject, scores }) {
   return {
     id: `${activity.id}-${user}`,
-    grades: [],
+    grades: scores
+      ? [
+          {
+            type: 'main',
+            subject,
+            grade: scores?.grade ?? null,
+            feedback: scores?.feedback ?? null,
+          },
+        ]
+      : [],
     isSubmitted: true,
     user,
     instance: {
@@ -43,21 +53,26 @@ export function useManualActivitiesForStudent({ klass, period, search }) {
     enabled: hasAllData,
   });
 
+  const { data: manualActivitiesScores } = useMyManualActivitiesScores({
+    classId: klass?.id,
+  });
+
   const { data: roles } = useRolesList({ details: true, select: (data) => keyBy(data, 'name') });
 
   const parsedActivities = useMemo(
     () =>
-      manualActivities?.map((activity) =>
-        parseActivity({
-          activity,
-          user,
-          roles,
-          // students: classStudents ?? [],
-          // subject: filters?.subject,
-          // scores: manualActivitiesScores,
-        })
-      ),
-    [manualActivities, user, roles]
+      manualActivities
+        ?.map((activity) =>
+          parseActivity({
+            activity,
+            user,
+            roles,
+            subject: klass?.subject?.id,
+            scores: manualActivitiesScores?.[activity.id],
+          })
+        )
+        .filter((activity) => activity.grades.length > 0),
+    [manualActivities, user, roles, manualActivitiesScores, klass?.subject?.id]
   );
 
   return {

--- a/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/SubjectsScoreList/components/SubjectScoreColumn/hooks/useManualActivitiesForStudent.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/SubjectsScoreList/components/SubjectScoreColumn/hooks/useManualActivitiesForStudent.js
@@ -1,13 +1,11 @@
 import { useMemo } from 'react';
 
-import useRolesList from '@assignables/requests/hooks/queries/useRolesList';
 import { getCookieToken } from '@users/session';
-import { keyBy } from 'lodash';
 
 import { useManualActivities } from '@scores/requests/hooks/queries/useManualActivities';
 import { useMyManualActivitiesScores } from '@scores/requests/hooks/queries/useMyManualActivitiesScores';
 
-function parseActivity({ activity, user, roles, subject, scores }) {
+function parseActivity({ activity, user, subject, scores }) {
   return {
     id: `${activity.id}-${user}`,
     grades: scores
@@ -28,7 +26,7 @@ function parseActivity({ activity, user, roles, subject, scores }) {
       },
       assignable: {
         role: activity.role,
-        roleDetails: roles?.[activity.role] ?? {},
+        roleDetails: {},
         asset: {
           name: activity.name,
         },
@@ -57,8 +55,6 @@ export function useManualActivitiesForStudent({ klass, period, search }) {
     classId: klass?.id,
   });
 
-  const { data: roles } = useRolesList({ details: true, select: (data) => keyBy(data, 'name') });
-
   const parsedActivities = useMemo(
     () =>
       manualActivities
@@ -66,13 +62,12 @@ export function useManualActivitiesForStudent({ klass, period, search }) {
           parseActivity({
             activity,
             user,
-            roles,
             subject: klass?.subject?.id,
             scores: manualActivitiesScores?.[activity.id],
           })
         )
         .filter((activity) => activity.grades.length > 0),
-    [manualActivities, user, roles, manualActivitiesScores, klass?.subject?.id]
+    [manualActivities, user, manualActivitiesScores, klass?.subject?.id]
   );
 
   return {

--- a/plugins/leemons-plugin-scores/frontend/src/components/Tables/ScoresBasicTable/ScoreCell/ScoreCell.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/Tables/ScoresBasicTable/ScoreCell/ScoreCell.js
@@ -9,7 +9,7 @@ import {
   NumberInput,
 } from '@bubbles-ui/components';
 import { ExpandDiagonalIcon } from '@bubbles-ui/icons/outline';
-import { isFunction, isNil } from 'lodash';
+import { isFunction } from 'lodash';
 import PropTypes from 'prop-types';
 
 import { SCORES_CELL_DEFAULT_PROPS } from './ScoreCell.constants';
@@ -86,17 +86,25 @@ const ScoreCell = ({
   ]);
 
   const renderValue = (_value) => {
-    if (!_value && !isSubmitted && isClosed)
-      return `${grades[0].letter ?? grades[0].number}${usePercentage ? '%' : ''} (${noActivityLabel})`;
+    const hasGrade = _value !== undefined && _value !== null;
 
-    if (!_value && isSubmitted)
+    // Use minimum grade if no grade and the activity is not submitted and is closed
+    if (!hasGrade && !isSubmitted && isClosed) {
+      return `${grades[0].letter ?? grades[0].number}${usePercentage ? '%' : ''} (${noActivityLabel})`;
+    }
+
+    // Use submitted label if the activity is submitted and not graded
+    if (!hasGrade && isSubmitted) {
       return (
         <Text color="success" role="productive" style={{ flex: 1 }}>
           {submittedLabel}
         </Text>
       );
+    }
 
-    if (isNil(_value)) return '-';
+    if (!hasGrade) {
+      return '-';
+    }
 
     let render = _value;
 

--- a/plugins/leemons-plugin-scores/frontend/src/components/Tables/ScoresBasicTable/ScoreCell/ScoreCell.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/Tables/ScoresBasicTable/ScoreCell/ScoreCell.js
@@ -63,6 +63,7 @@ const ScoreCell = ({
   isClosed,
   grades,
   usePercentage,
+  source,
   row,
   column,
   setValue,
@@ -72,6 +73,8 @@ const ScoreCell = ({
 }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(value ?? grades[0].number);
+
+  const isAssignable = source === 'assignables';
 
   useEffect(() => {
     if (value !== editValue) {
@@ -94,7 +97,7 @@ const ScoreCell = ({
     }
 
     // Use submitted label if the activity is submitted and not graded
-    if (!hasGrade && isSubmitted) {
+    if (!hasGrade && isSubmitted && isAssignable) {
       return (
         <Text color="success" role="productive" style={{ flex: 1 }}>
           {submittedLabel}
@@ -168,23 +171,25 @@ const ScoreCell = ({
 
     return (
       <Box className={classes.inputContainer} ref={setInputContainer} onClick={onClickHandler}>
-        {!!allowChange && !!isEditing && (
-          <SelectScore
-            value={editValue}
-            grades={grades}
-            onChange={setEditValue}
-            onClose={onCloseThenChangeHandler}
-            style={{ flex: 1 }}
-            ref={selectRef}
-            isCustom={isCustom}
-          />
-        )}
-        {(!isEditing || !allowChange) && (
-          <Text color={isSubmitted ? 'primary' : 'error'} role="productive" style={{ flex: 1 }}>
-            {renderValue(value)}
-          </Text>
-        )}
-        {isEditing && !isCustom && (
+        <Box className={classes.score}>
+          {!!allowChange && !!isEditing && (
+            <SelectScore
+              value={editValue}
+              grades={grades}
+              onChange={setEditValue}
+              onClose={onCloseThenChangeHandler}
+              style={{ flex: 1 }}
+              ref={selectRef}
+              isCustom={isCustom}
+            />
+          )}
+          {(!isEditing || !allowChange) && (
+            <Text color={isSubmitted ? 'primary' : 'error'} role="productive" style={{ flex: 1 }}>
+              {renderValue(value)}
+            </Text>
+          )}
+        </Box>
+        {isEditing && !isCustom && isAssignable && (
           <Box className={classes.expandIcon}>
             <IconButton
               variant="transparent"

--- a/plugins/leemons-plugin-scores/frontend/src/components/Tables/ScoresBasicTable/ScoreCell/ScoreCell.styles.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/Tables/ScoresBasicTable/ScoreCell/ScoreCell.styles.js
@@ -1,10 +1,4 @@
-import {
-  createStyles,
-  pxToRem,
-  getPaddings,
-  getFontExpressive,
-  getFontProductive,
-} from '@bubbles-ui/components';
+import { createStyles } from '@bubbles-ui/components';
 
 export const ScoreCellStyles = createStyles((theme, { isEditing, allowChange }) => ({
   root: {
@@ -16,11 +10,15 @@ export const ScoreCellStyles = createStyles((theme, { isEditing, allowChange }) 
     border: '1px solid transparent',
     borderColor: isEditing && theme.colors.interactive01d,
   },
+  score: {
+    width: '100%',
+  },
   inputContainer: {
     width: '100%',
     height: '100%',
     display: 'flex',
-    justifyContent: 'center',
+    justifyContent: 'space-between',
+    gap: 0,
     alignItems: 'center',
     cursor: 'pointer',
     textAlign: 'center',

--- a/plugins/leemons-plugin-scores/frontend/src/components/Tables/ScoresBasicTable/ScoresBasicTable.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/Tables/ScoresBasicTable/ScoresBasicTable.js
@@ -146,7 +146,7 @@ const ScoresBasicTable = ({
           <Box className={classes.separator} />
           <Box className={classes.studentInfo}>
             <Text color="primary" role="productive">
-              {avgScore}
+              {isNaN(avgScore) ? '-' : avgScore}
               {usePercentage ? '%' : ''}
             </Text>
           </Box>

--- a/plugins/leemons-plugin-scores/frontend/src/components/Tables/ScoresBasicTable/ScoresBasicTable.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/Tables/ScoresBasicTable/ScoresBasicTable.js
@@ -92,21 +92,23 @@ const ScoresBasicTable = ({
 
   const getActivities = (studentActivities, studentId) => {
     const activitiesObject = {};
-    activities.forEach(({ id }) => {
+    activities.forEach(({ id, source }) => {
       const activity = studentActivities.find((studentActivity) => studentActivity?.id === id);
       activitiesObject[id] = {
         score: useNumbers ? activity?.score : findGradeLetter(activity?.score),
         isSubmitted: activity?.isSubmitted,
+        source,
       };
     });
     const expandedActivities = expandedData?.value.find(
       (student) => student.id === studentId
     )?.activities;
-    expandedData?.activities?.forEach(({ id }) => {
+    expandedData?.activities?.forEach(({ id, source }) => {
       const activity = expandedActivities.find((expandedActivity) => expandedActivity?.id === id);
       activitiesObject[id] = {
         score: useNumbers ? activity?.score : findGradeLetter(activity?.score),
         isSubmitted: activity?.isSubmitted,
+        source,
       };
     });
     return activitiesObject;
@@ -228,6 +230,7 @@ const ScoresBasicTable = ({
             submittedLabel={labels.submitted}
             allowChange={activity.allowChange && !viewOnly}
             isSubmitted={value.isSubmitted}
+            source={value.source}
             isClosed={isDeadlineFinished}
             grades={grades}
             usePercentage={usePercentage}
@@ -273,6 +276,7 @@ const ScoresBasicTable = ({
                   submittedLabel={labels.submitted}
                   allowChange={expandedActivity.allowChange && !viewOnly}
                   isSubmitted={value.isSubmitted}
+                  source={value.source}
                   grades={grades}
                   usePercentage={usePercentage}
                   row={row}

--- a/plugins/leemons-plugin-scores/frontend/src/components/Weights/components/WeightConfigDrawer/components/SelectType.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/Weights/components/WeightConfigDrawer/components/SelectType.js
@@ -1,9 +1,9 @@
-import React, { useMemo } from 'react';
-
-import { Select, ContextContainer } from '@bubbles-ui/components';
+import { useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
+import { Select, ContextContainer } from '@bubbles-ui/components';
 import useTranslateLoader from '@multilanguage/useTranslateLoader';
+
 import { prefixPN } from '@scores/helpers';
 
 export default function SelectType() {
@@ -21,7 +21,6 @@ export default function SelectType() {
         label: typesT('roles'),
         value: 'roles',
       },
-      // ! DISABLE MODULES FOR NOW
       {
         label: typesT('modules'),
         value: 'modules',

--- a/plugins/leemons-plugin-scores/frontend/src/components/Weights/components/WeightConfigDrawer/components/Weighting/hooks/useModulesData.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/Weights/components/WeightConfigDrawer/components/Weighting/hooks/useModulesData.js
@@ -1,13 +1,35 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 
-import { ImageLoader } from '@bubbles-ui/components';
-
-import useWeights from '@scores/requests/hooks/queries/useWeights';
-import useSearchOngoingActivities from '@assignables/requests/hooks/queries/useSearchOngoingActivities';
 import useInstances from '@assignables/requests/hooks/queries/useInstances';
 import useRole from '@assignables/requests/hooks/queries/useRole';
+import useSearchOngoingActivities from '@assignables/requests/hooks/queries/useSearchOngoingActivities';
+import { ImageLoader } from '@bubbles-ui/components';
+
+import { useManualActivities } from '@scores/requests/hooks/queries/useManualActivities';
+import useWeights from '@scores/requests/hooks/queries/useWeights';
 
 const MODULES_ROLE = 'learningpaths.module';
+
+function useManualActivitiesAsInstances({ class: klass }) {
+  const { data: manualActivities, isLoading: manualActivitiesLoading } = useManualActivities({
+    classId: klass,
+    enabled: !!klass,
+  });
+
+  const instances = manualActivities?.map((activity) => ({
+    id: activity.id,
+    assignable: {
+      asset: {
+        name: activity.name,
+      },
+    },
+  }));
+
+  return {
+    isLoading: manualActivitiesLoading,
+    data: instances,
+  };
+}
 
 export default function useModulesData({ class: klass }) {
   const { data: role, isLoading: roleLoading } = useRole({ role: MODULES_ROLE });
@@ -27,10 +49,15 @@ export default function useModulesData({ class: klass }) {
     enabled: !!modules?.items?.length,
   });
 
-  const data = useMemo(() => {
-    if (!moduleInstances || !modules?.count) return [];
+  const { data: manualActivitiesInstances, isLoading: manualActivitiesInstancesLoading } =
+    useManualActivitiesAsInstances({ class: klass });
 
-    return moduleInstances?.map((module) => {
+  const instances = (moduleInstances ?? [])?.concat(manualActivitiesInstances ?? []);
+
+  const data = useMemo(() => {
+    if (!instances || !modules?.count) return [];
+
+    return instances?.map((module) => {
       const weight = weights?.weights?.find((w) => w.id === module.id);
 
       return {
@@ -42,14 +69,15 @@ export default function useModulesData({ class: klass }) {
         isNew: weights?.weights && !weight,
       };
     });
-  }, [weights, moduleInstances, modules?.count, role]);
+  }, [weights, instances, modules?.count, role]);
 
   return {
     isLoading:
       roleLoading ||
       weightsLoading ||
       modulesLoading ||
-      (moduleInstancesLoading && !!modules?.items?.length),
+      manualActivitiesInstancesLoading ||
+      (moduleInstancesLoading && !!instances?.length),
     data,
   };
 }

--- a/plugins/leemons-plugin-scores/frontend/src/components/__DEPRECATED__/Notebook/components/ActivitiesTab/useTableData.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/__DEPRECATED__/Notebook/components/ActivitiesTab/useTableData.js
@@ -1,13 +1,15 @@
 import React from 'react';
-import useSearchAssignableInstances from '@assignables/hooks/assignableInstance/useSearchAssignableInstancesQuery';
+
 import useSessionClasses from '@academic-portfolio/hooks/useSessionClasses';
-import { map, uniq } from 'lodash';
-import { useUserAgentsInfo } from '@users/hooks';
+import useSearchAssignableInstances from '@assignables/hooks/assignableInstance/useSearchAssignableInstancesQuery';
 import useProgramEvaluationSystem from '@assignables/hooks/useProgramEvaluationSystem';
-import { useCache } from '@common';
 import useInstances from '@assignables/requests/hooks/queries/useInstances';
-import { useParsedActivities } from './useParsedActivities';
+import { useCache } from '@common';
+import { useUserAgentsInfo } from '@users/hooks';
+import { map, uniq } from 'lodash';
+
 import useFinalData from './useFinalData';
+import { useParsedActivities } from './useParsedActivities';
 
 function useSelectedClasses(filters) {
   const { data: sessionClasses } = useSessionClasses(
@@ -81,7 +83,7 @@ function useFilteredAssignableInstances({ assignableInstances, filters }) {
           !assignableInstance.assignable.asset.name
             .toLowerCase()
             .includes(filters.search.toLowerCase())) ||
-        !assignableInstance.requiresScoring ||
+        !assignableInstance.gradable ||
         (!filters.showNonCalificables && !assignableInstance.gradable) ||
         assignableInstance?.metadata?.module?.type === 'module'
       )

--- a/plugins/leemons-plugin-scores/frontend/src/components/__DEPRECATED__/ScoresPage/Filters/Filters.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/__DEPRECATED__/ScoresPage/Filters/Filters.js
@@ -53,7 +53,7 @@ export function Filters({
     setValue,
   });
 
-  const { startDate, endDate } = useAcademicCalendarDates({ control, selectedClass });
+  const { startDate, endDate } = useAcademicCalendarDates({ selectedClass });
 
   useOnChange(selectedClass, selectedPeriod, onChange);
 

--- a/plugins/leemons-plugin-scores/frontend/src/components/__DEPRECATED__/ScoresPage/Filters/components/SelectPeriod.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/__DEPRECATED__/ScoresPage/Filters/components/SelectPeriod.js
@@ -27,13 +27,8 @@ function usePeriodsData({ periods, t }) {
       label: t('final'),
       group: periodTypes?.academicCalendar,
     });
-  } else {
-    data.push({
-      value: 'fullCourse',
-      label: t('fullCourse'),
-      group: periodTypes?.academicCalendar,
-    });
   }
+
   return data;
 }
 

--- a/plugins/leemons-plugin-scores/frontend/src/components/__DEPRECATED__/StudentScoresPage/StudentActivities.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/__DEPRECATED__/StudentScoresPage/StudentActivities.js
@@ -1,18 +1,21 @@
+import React, { useMemo } from 'react';
+
+import { SelectSubject } from '@academic-portfolio/components/SelectSubject';
 import { getClassIcon } from '@academic-portfolio/helpers/getClassIcon';
 import { getClassImage } from '@academic-portfolio/helpers/getClassImage';
+import { useRoles } from '@assignables/components/Ongoing/AssignmentList/components/Filters/components/Type/Type';
 import useSearchAssignableInstances from '@assignables/hooks/assignableInstance/useSearchAssignableInstancesQuery';
 import useProgramEvaluationSystem from '@assignables/hooks/useProgramEvaluationSystem';
 import useAssignations from '@assignables/requests/hooks/queries/useAssignations';
 import { Box, Loader, ScoreFronstage, Select, Switch, createStyles } from '@bubbles-ui/components';
-import { useScores } from '@scores/requests/hooks/queries';
+import getNearestScale from '@scorm/helpers/getNearestScale';
+import useUserAgents from '@users/hooks/useUserAgents';
 import { map } from 'lodash';
 import PropTypes from 'prop-types';
-import React, { useMemo } from 'react';
-import getNearestScale from '@scorm/helpers/getNearestScale';
-import { SelectSubject } from '@academic-portfolio/components/SelectSubject';
-import { useRoles } from '@assignables/components/Ongoing/AssignmentList/components/Filters/components/Type/Type';
-import useUserAgents from '@users/hooks/useUserAgents';
+
 import { EmptyState } from '../Notebook/components/ActivitiesTab/EmptyState';
+
+import { useScores } from '@scores/requests/hooks/queries';
 
 function LoadingState() {
   return (
@@ -146,7 +149,7 @@ export default function StudentActivities({ klasses, filters, labels }) {
     const classesIds = [];
     const filteredActivities = [];
     activities?.forEach((activity) => {
-      if (!activity.requiresScoring || activity?.metadata?.module?.type === 'module') return;
+      if (!activity.gradable || activity?.metadata?.module?.type === 'module') return;
 
       // Filters non-calificable activities except when the filter is set to TRUE
       // If type is selected, filters activities matching type

--- a/plugins/leemons-plugin-scores/frontend/src/requests/hooks/keys/manualActivities.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/hooks/keys/manualActivities.js
@@ -1,0 +1,23 @@
+export const allManualActivitiesKey = [
+  {
+    plugin: 'plugin.scores',
+    scope: 'scores',
+  },
+];
+
+export const allManualActivitiesSearchKey = [
+  {
+    ...allManualActivitiesKey[0],
+    action: 'search',
+  },
+];
+
+export const manualActivitiesSearchKey = ({ classId, startDate, endDate }) => [
+  {
+    ...allManualActivitiesSearchKey[0],
+
+    classId,
+    startDate,
+    endDate,
+  },
+];

--- a/plugins/leemons-plugin-scores/frontend/src/requests/hooks/keys/manualActivities.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/hooks/keys/manualActivities.js
@@ -35,3 +35,10 @@ export const manualActivityScoresKey = ({ classId }) => [
     classId,
   },
 ];
+
+export const myManualActivityScoresKey = ({ classId, user }) => [
+  {
+    ...manualActivityScoresKey({ classId })[0],
+    user,
+  },
+];

--- a/plugins/leemons-plugin-scores/frontend/src/requests/hooks/keys/manualActivities.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/hooks/keys/manualActivities.js
@@ -1,7 +1,7 @@
 export const allManualActivitiesKey = [
   {
     plugin: 'plugin.scores',
-    scope: 'scores',
+    scope: 'manualActivities',
   },
 ];
 
@@ -12,12 +12,26 @@ export const allManualActivitiesSearchKey = [
   },
 ];
 
-export const manualActivitiesSearchKey = ({ classId, startDate, endDate }) => [
+export const classManualActivitiesKey = ({ classId }) => [
   {
-    ...allManualActivitiesSearchKey[0],
-
+    ...allManualActivitiesKey[0],
     classId,
+  },
+];
+
+export const manualActivitiesSearchKey = ({ classId, startDate, endDate, search }) => [
+  {
+    ...classManualActivitiesKey({ classId })[0],
     startDate,
     endDate,
+    search,
+  },
+];
+
+export const manualActivityScoresKey = ({ classId }) => [
+  {
+    ...allManualActivitiesKey[0],
+    action: 'scores',
+    classId,
   },
 ];

--- a/plugins/leemons-plugin-scores/frontend/src/requests/hooks/mutations/useCreateManualActivityMutation.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/hooks/mutations/useCreateManualActivityMutation.js
@@ -1,14 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { manualActivitiesSearchKey } from '../keys/manualActivities';
+import { classManualActivitiesKey } from '../keys/manualActivities';
 
 import { createManualActivity } from '@scores/requests/manualActivities/create';
 
-/**
- * Hook to create a manual activity
- * @param {import("@tanstack/react-query").UseMutationOptions} options - The options for the mutation
- * @returns {import("@tanstack/react-query").UseMutationResult} The mutation result
- */
 export function useCreateManualActivityMutation() {
   const queryClient = useQueryClient();
 
@@ -16,7 +11,7 @@ export function useCreateManualActivityMutation() {
     mutationFn: createManualActivity,
     onSuccess: (_, { classId }) => {
       queryClient.invalidateQueries({
-        queryKey: manualActivitiesSearchKey({ classId }),
+        queryKey: classManualActivitiesKey({ classId }),
       });
     },
   });

--- a/plugins/leemons-plugin-scores/frontend/src/requests/hooks/mutations/useCreateManualActivityMutation.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/hooks/mutations/useCreateManualActivityMutation.js
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { manualActivitiesSearchKey } from '../keys/manualActivities';
+
+import { createManualActivity } from '@scores/requests/manualActivities/create';
+
+/**
+ * Hook to create a manual activity
+ * @param {import("@tanstack/react-query").UseMutationOptions} options - The options for the mutation
+ * @returns {import("@tanstack/react-query").UseMutationResult} The mutation result
+ */
+export function useCreateManualActivityMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createManualActivity,
+    onSuccess: (_, { classId }) => {
+      queryClient.invalidateQueries({
+        queryKey: manualActivitiesSearchKey({ classId }),
+      });
+    },
+  });
+}

--- a/plugins/leemons-plugin-scores/frontend/src/requests/hooks/mutations/useSetManualActivityScoresMutation.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/hooks/mutations/useSetManualActivityScoresMutation.js
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { uniq } from 'lodash';
+
+import { manualActivityScoresKey } from '../keys/manualActivities';
+
+import { setManualActivityScores } from '@scores/requests/manualActivities/scores/set';
+
+export function useSetManualActivityScoresMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: setManualActivityScores,
+    onSuccess: (_, { scores }) => {
+      const classesIds = uniq(scores.map((score) => score.class));
+      classesIds.forEach((classId) => {
+        queryClient.invalidateQueries({
+          queryKey: manualActivityScoresKey({ classId }),
+        });
+      });
+    },
+  });
+}

--- a/plugins/leemons-plugin-scores/frontend/src/requests/hooks/queries/useManualActivities.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/hooks/queries/useManualActivities.js
@@ -1,0 +1,31 @@
+import { useVariantForQueryKey } from "@common/queries";
+import { useQuery } from "@tanstack/react-query";
+
+import { manualActivitiesSearchKey } from "../keys/manualActivities";
+
+import { searchManualActivities } from "@scores/requests/manualActivities/search";
+
+/**
+ * Hook to search for manual activities
+ * @param {object} props
+ * @param {string} props.classId - The class ID in LRN format
+ * @param {string} props.startDate - The start date of the activities in ISO format
+ * @param {string} props.endDate - The end date of the activities in ISO format
+ * @param {import("@tanstack/react-query").UseQueryOptions} props.options - The options for the query
+ */
+export function useManualActivities({ classId, startDate, endDate, ...options }) {
+  const queryKey = manualActivitiesSearchKey({ classId, startDate, endDate });
+  const queryFn = () => searchManualActivities({ classId, startDate, endDate });
+
+  useVariantForQueryKey(queryKey, {
+    modificationTrend: 'lazy',
+  })
+
+  const { data, isLoading, error } = useQuery({
+    ...options,
+    queryKey,
+    queryFn,
+  });
+
+  return { data, isLoading, error };
+}

--- a/plugins/leemons-plugin-scores/frontend/src/requests/hooks/queries/useManualActivitiesScores.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/hooks/queries/useManualActivitiesScores.js
@@ -1,9 +1,9 @@
 import { useVariantForQueryKey } from '@common/queries';
 import { useQuery } from '@tanstack/react-query';
 
-import { manualActivitiesSearchKey } from '../keys/manualActivities';
+import { manualActivityScoresKey } from '../keys/manualActivities';
 
-import { searchManualActivities } from '@scores/requests/manualActivities/search';
+import { getManualActivityScores } from '@scores/requests/manualActivities/scores/get';
 
 /**
  * Hook to search for manual activities
@@ -13,9 +13,9 @@ import { searchManualActivities } from '@scores/requests/manualActivities/search
  * @param {string} props.endDate - The end date of the activities in ISO format
  * @param {import("@tanstack/react-query").UseQueryOptions} props.options - The options for the query
  */
-export function useManualActivities({ classId, startDate, endDate, search, ...options }) {
-  const queryKey = manualActivitiesSearchKey({ classId, startDate, endDate, search });
-  const queryFn = () => searchManualActivities({ classId, startDate, endDate, search });
+export function useManualActivitiesScores({ classId, ...options }) {
+  const queryKey = manualActivityScoresKey({ classId });
+  const queryFn = () => getManualActivityScores(classId);
 
   useVariantForQueryKey(queryKey, {
     modificationTrend: 'lazy',

--- a/plugins/leemons-plugin-scores/frontend/src/requests/hooks/queries/useMyManualActivitiesScores.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/hooks/queries/useMyManualActivitiesScores.js
@@ -1,0 +1,31 @@
+import { useVariantForQueryKey } from '@common/queries';
+import { useQuery } from '@tanstack/react-query';
+import { useUserAgents } from '@users/hooks';
+
+import { manualActivityScoresKey } from '../keys/manualActivities';
+
+import { getMyManualActivityScores } from '@scores/requests/manualActivities/scores/myScores';
+
+/**
+ * Hook to search for manual activities of the current user
+ * @param {object} props
+ * @param {string} props.classId - The class ID in LRN format
+ * @param {string} props.startDate - The start date of the activities in ISO format
+ * @param {string} props.endDate - The end date of the activities in ISO format
+ * @param {import("@tanstack/react-query").UseQueryOptions} props.options - The options for the query
+ */
+export function useMyManualActivitiesScores({ classId, ...options }) {
+  const [user] = useUserAgents();
+  const queryKey = manualActivityScoresKey({ classId, user });
+  const queryFn = () => getMyManualActivityScores(classId);
+
+  useVariantForQueryKey(queryKey, {
+    modificationTrend: 'lazy',
+  });
+
+  return useQuery({
+    ...options,
+    queryKey,
+    queryFn,
+  });
+}

--- a/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/create.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/create.js
@@ -1,0 +1,17 @@
+/**
+ * Creates a manual activity
+ * @param {object} manualActivity
+ * @param {string} manualActivity.name - The name of the activity
+ * @param {string} manualActivity.description - The description of the activity
+ * @param {string} manualActivity.date - The date of the activity in ISO format
+ * @param {string} manualActivity.type - The type of activity (task, test, etc)
+ * @param {string} manualActivity.classId - The class ID in LRN format
+ */
+export async function createManualActivity(manualActivity) {
+  const { id } = await leemons.api('v1/scores/manualActivities', {
+    method: 'POST',
+    body: { manualActivity },
+  });
+
+  return id;
+}

--- a/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/remove.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/remove.js
@@ -1,0 +1,7 @@
+export async function removeManualActivity({ id }) {
+  const { removed } = await leemons.api(`v1/scores/manualActivities/${id}`, {
+    method: 'DELETE',
+  });
+
+  return removed;
+}

--- a/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/scores/get.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/scores/get.js
@@ -1,0 +1,12 @@
+/**
+ *
+ * @param {string} classId
+ * @returns
+ */
+export async function getManualActivityScores(classId) {
+  const { data } = await leemons.api(`v1/scores/manualActivities/scores/class/${classId}`, {
+    method: 'GET',
+  });
+
+  return data;
+}

--- a/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/scores/myScores.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/scores/myScores.js
@@ -1,0 +1,12 @@
+/**
+ *
+ * @param {string} classId
+ * @returns
+ */
+export async function getMyManualActivityScores(classId) {
+  const { data } = await leemons.api(`v1/scores/manualActivities/scores/class/${classId}/user/me`, {
+    method: 'GET',
+  });
+
+  return data;
+}

--- a/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/scores/set.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/scores/set.js
@@ -1,0 +1,14 @@
+/**
+ *
+ * @param {object[]} scores
+ * @param {string} scores.user
+ * @param {string} scores.activity,
+ * @param {string} scores.grade
+ * @param {string} scores.class
+ */
+export function setManualActivityScores(scores) {
+  return leemons.api('v1/scores/manualActivities/scores', {
+    method: 'PUT',
+    body: scores,
+  });
+}

--- a/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/search.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/search.js
@@ -8,9 +8,13 @@
 export async function searchManualActivities({ classId, startDate, endDate, search }) {
   const searchParams = new URLSearchParams();
 
-  searchParams.set('startDate', startDate);
-  searchParams.set('endDate', endDate);
+  if (startDate) {
+    searchParams.set('startDate', startDate);
+  }
 
+  if (endDate) {
+    searchParams.set('endDate', endDate);
+  }
   if (search) {
     searchParams.set('search', search);
   }

--- a/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/search.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/search.js
@@ -5,9 +5,18 @@
  * @param {string} props.startDate - The start date of the activities in ISO format
  * @param {string} props.endDate - The end date of the activities in ISO format
  */
-export async function searchManualActivities({ classId, startDate, endDate }) {
+export async function searchManualActivities({ classId, startDate, endDate, search }) {
+  const searchParams = new URLSearchParams();
+
+  searchParams.set('startDate', startDate);
+  searchParams.set('endDate', endDate);
+
+  if (search) {
+    searchParams.set('search', search);
+  }
+
   const { data } = await leemons.api(
-    `v1/scores/manualActivities/class/${classId}?startDate=${startDate}&endDate=${endDate}`,
+    `v1/scores/manualActivities/class/${classId}?${searchParams.toString()}`,
     {
       method: 'GET',
     }

--- a/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/search.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/search.js
@@ -1,0 +1,17 @@
+/**
+ * Searches for manual activities
+ * @param {object} props
+ * @param {string} props.classId - The class ID in LRN format
+ * @param {string} props.startDate - The start date of the activities in ISO format
+ * @param {string} props.endDate - The end date of the activities in ISO format
+ */
+export async function searchManualActivities({ classId, startDate, endDate }) {
+  const { data } = await leemons.api(
+    `v1/scores/manualActivities/class/${classId}?startDate=${startDate}&endDate=${endDate}`,
+    {
+      method: 'GET',
+    }
+  );
+
+  return data;
+}

--- a/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/update.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/update.js
@@ -1,0 +1,16 @@
+/**
+ * Updates a manual activity
+ * @param {object} manualActivity
+ * @param {string} manualActivity.id - The ID of the activity
+ * @param {string} manualActivity.name - The name of the activity
+ * @param {string} manualActivity.description - The description of the activity
+ * @param {string} manualActivity.date - The date of the activity in ISO format
+ * @param {string} manualActivity.type - The type of activity (task, test, etc)
+ * @param {string} manualActivity.classId - The class ID in LRN format
+ */
+export function updateManualActivity({ id, ...manualActivity }) {
+  return leemons.api(`v1/scores/manualActivities/${id}`, {
+    method: 'PUT',
+    body: manualActivity,
+  });
+}

--- a/plugins/leemons-plugin-scores/frontend/src/stores/evaluationNotebookStore.js
+++ b/plugins/leemons-plugin-scores/frontend/src/stores/evaluationNotebookStore.js
@@ -5,6 +5,7 @@ const { create } = require('zustand');
 const initialState = {
   filters: null,
   tableData: null,
+  isPeriodPublished: false,
 };
 
 const useEvaluationNotebookStore = create((set, get) => ({
@@ -20,6 +21,7 @@ const useEvaluationNotebookStore = create((set, get) => ({
   },
   setTableData: (tableData) => set({ tableData }),
   reset: () => set(initialState),
+  setIsPeriodPublished: (isPeriodPublished) => set({ isPeriodPublished }),
 }));
 
 export default useEvaluationNotebookStore;


### PR DESCRIPTION
# feat(scores): implement manual activities with grading functionality

## 🔍 Description
This PR introduces Manual Activities feature in the Scores module, allowing teachers to create and grade manual activities within the evaluation system.

### Key Changes
- ✨ Added Manual Activities creation and management
- 📊 Integrated manual activities into student evaluation notebook
- 🔒 Implemented period-based restrictions for manual activities
- 🎯 Enhanced scoring logic and grade visualization
- 📋 Added validation and data requirements

### Technical Details
- Created backend endpoints for manual activities management
- Implemented ManualActivityDrawer component for activity creation
- Added period date restrictions for manual activities
- Enhanced scoring logic in ScoreCell component
- Integrated with existing evaluation notebook and module weighting systems
- Added LRN format validation to ajv validator
- Implemented common leemonsFields for MongoDB models

## 📝 Notes
This feature enhances the scoring system by allowing teachers to create and grade activities that happen outside the digital platform, such as physical assignments or in-class participation.
