### PR TITLE
fix(menu-builder): remove unnecessary regex from permission query

### DIFF
--- a/plugins/leemons-plugin-menu-builder/backend/core/menu/getIfHasPermission.js
+++ b/plugins/leemons-plugin-menu-builder/backend/core/menu/getIfHasPermission.js
@@ -62,9 +62,9 @@ async function getIfHasPermission({ menuKey, ctx }) {
   }
 
   // We take only the menu items to which we have access.
-  const typeTemplate = _.escapeRegExp(ctx.prefixPN(`${menuKey}.menu-item`));
+  const typeTemplate = ctx.prefixPN(`${menuKey}.menu-item`);
   const query = {
-    type: { $regex: `^${typeTemplate}` },
+    type: typeTemplate,
   };
   query.$or = queryPermissions;
   const menuItemPermissions = await ctx.tx.call('users.permissions.findItems', { params: query });


### PR DESCRIPTION
Refactored the `getIfHasPermission` function to eliminate the use of regex in the `type` query, improving performance by directly using the `typeTemplate` string. This change ensures more efficient permission checks for menu items.