### PR TITLE
fix(academic-portfolio): update class handling to include classWithoutGroupId

### DIFF
--- a/plugins/leemons-plugin-academic-portfolio/backend/core/classes/updateClass.js
+++ b/plugins/leemons-plugin-academic-portfolio/backend/core/classes/updateClass.js
@@ -37,7 +37,14 @@ function emitUpdateClassEvent({
 
   if (userAgent?.id) {
     ctx.socket.emit(userAgent.id, eventName, {
-      class: pick(classData, ['id', 'alias', 'classroomId', 'subject', 'program']),
+      class: pick(classData, [
+        'id',
+        'alias',
+        'classroomId',
+        'classWithoutGroupId',
+        'subject',
+        'program',
+      ]),
       status,
       message,
       error,

--- a/plugins/leemons-plugin-academic-portfolio/frontend/globalContext.js
+++ b/plugins/leemons-plugin-academic-portfolio/frontend/globalContext.js
@@ -23,7 +23,7 @@ function getSeverity(status) {
 }
 
 function getClassName(classData) {
-  return classData?.alias ?? classData?.classroomId;
+  return classData?.alias ?? classData?.classWithoutGroupId ?? classData?.classroomId ?? '-';
 }
 
 function processNotification({

--- a/plugins/leemons-plugin-academic-portfolio/frontend/src/components/AcademicTree/SubjectView/SubjectView.js
+++ b/plugins/leemons-plugin-academic-portfolio/frontend/src/components/AcademicTree/SubjectView/SubjectView.js
@@ -129,9 +129,15 @@ const SubjectView = ({ subjectTreeNode, program, scrollRef, openEnrollmentDrawer
       requestBody.schedule = requestBody.schedule.days;
     }
 
+    requestBody.subject = subjectTreeNode?.itemId;
+
     mutateClass(requestBody, {
       onSuccess: () => {
-        const className = selectedClass?.alias ?? selectedClass?.classroomId;
+        const className =
+          selectedClass?.alias ??
+          selectedClass?.classWithoutGroupId ??
+          selectedClass?.classroomId ??
+          '-';
         const notificationId = `${SOCKET_EVENTS.CLASS_UPDATE}:${requestBody.id}`;
 
         notifications.showNotification({

--- a/plugins/leemons-plugin-academic-portfolio/frontend/src/components/SubjectSetupDrawer/SubjectSetupDrawer.js
+++ b/plugins/leemons-plugin-academic-portfolio/frontend/src/components/SubjectSetupDrawer/SubjectSetupDrawer.js
@@ -138,7 +138,11 @@ const SubjectSetupDrawer = ({
     );
     const classesUpdatePromises = [];
     classesToUpdate.forEach((classToUpdate) => {
-      const className = classToUpdate?.alias ?? classToUpdate?.classroomId;
+      const className =
+        classToUpdate?.alias ??
+        classToUpdate?.classWithoutGroupId ??
+        classToUpdate?.classroomId ??
+        '-';
       const notificationId = `${SOCKET_EVENTS.CLASS_UPDATE}:${classToUpdate.id}`;
 
       notifications.showNotification({


### PR DESCRIPTION
- Updated `emitUpdateClassEvent` to include `classWithoutGroupId` in the emitted data.
- Modified `getClassName` to prioritize `classWithoutGroupId` when determining class name.
- Adjusted `SubjectView` and `SubjectSetupDrawer` components to handle `classWithoutGroupId`.
- Enhanced `useMutateClass` hook with optimistic updates and error handling for class updates.