### PR TITLE
fix(menu-builder): add basic permission check for public menu items

### DIFF
--- a/plugins/leemons-plugin-menu-builder/backend/core/menu/getIfHasPermission.js
+++ b/plugins/leemons-plugin-menu-builder/backend/core/menu/getIfHasPermission.js
@@ -58,6 +58,12 @@ async function getIfHasPermission({ menuKey, ctx }) {
       throw new LeemonsError(ctx, { message: `You do not have access to the '${menuKey}' menu` });
   }
 
+  // Add basic permission to query
+  queryPermissions.push({
+    permissionName: 'users.any',
+    actionName: ['view'],
+  });
+
   // We take only the menu items to which we have access.
   const typeTemplate = ctx.prefixPN(`${menuKey}.menu-item`);
   const query = {


### PR DESCRIPTION
Added a basic permission 'users.any' with action 'view' to the queryPermissions array to ensure users have access to public menu items. This change addresses an issue where users were unable to view certain menu items due to missing permissions.