### PR TITLE
fix(scores): Handle missing period data in evaluation closed email

### DIFF
--- a/plugins/leemons-plugin-scores/backend/core/emails/sendEvaluationClosedEmail.js
+++ b/plugins/leemons-plugin-scores/backend/core/emails/sendEvaluationClosedEmail.js
@@ -48,8 +48,8 @@ async function sendEvaluationClosedEmail({ scores, ctx }) {
         month: '2-digit',
         day: '2-digit',
       }),
-
-      periodName: periodData.name,
+      // TODO: If periodData is null, we need to get the period name from the AcademicCalendar start and end dates. Example: "2024 - 2025"
+      periodName: periodData?.name ?? '',
       subjectName: classData[0].subject.name,
       subjectIconUrl: subjectIconUrl ?? null,
       subjectColor: classData[0].subject.color ?? null,

--- a/plugins/leemons-plugin-scores/backend/emails/EvaluationClosed.jsx
+++ b/plugins/leemons-plugin-scores/backend/emails/EvaluationClosed.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import EmailLayout from '@leemons/emails/src/emails/EmailLayout.jsx';
 import { Button, Container, Text } from '@react-email/components';
 import PropTypes from 'prop-types';
@@ -11,7 +10,7 @@ const messages = {
   en: {
     title: 'Evaluation closed',
     subtitle: 'We would like to inform you that on {{it.date}}',
-    subtitle2: '',
+    subtitle2: 'the period',
     subtitle3: 'for this subject has been closed',
 
     yourGrade: 'Your grade was:',
@@ -24,7 +23,7 @@ const messages = {
   es: {
     title: 'Evaluación finalizada',
     subtitle: 'Te comunicamos que con fecha {{it.date}}',
-    subtitle2: 'ha finalizado la',
+    subtitle2: 'ha finalizado el periodo',
     subtitle3: 'de la asignatura',
 
     yourGrade: 'Tu nota ha sido:',


### PR DESCRIPTION
- Add fallback for period name when periodData is null
- Update email template to improve period description