### PR TITLE
fix: update react-to-print dependency and refactor print components

### DIFF
--- a/plugins/leemons-plugin-academic-calendar/frontend/package.json
+++ b/plugins/leemons-plugin-academic-calendar/frontend/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.46.1",
     "react-router-dom": "^5.3.3",
-    "react-to-print": "^2.14.13"
+    "react-to-print": "^3.0.1"
   },
   "devDependencies": {}
 }

--- a/plugins/leemons-plugin-academic-calendar/frontend/src/components/PrintCalendar.js
+++ b/plugins/leemons-plugin-academic-calendar/frontend/src/components/PrintCalendar.js
@@ -1,15 +1,37 @@
-import React, { forwardRef } from 'react';
-import PropTypes from 'prop-types';
+import { forwardRef } from 'react';
+
 import { BigCalendar } from '@bubbles-ui/calendars';
 import { Stack, Box, Title } from '@bubbles-ui/components';
-import CalendarKey from '@academic-calendar/components/CalendarKey';
 import useTranslateLoader from '@multilanguage/useTranslateLoader';
-import prefixPN from '@academic-calendar/helpers/prefixPN';
+import PropTypes from 'prop-types';
+
 import Calendar from './Calendar';
+
+import CalendarKey from '@academic-calendar/components/CalendarKey';
+import prefixPN from '@academic-calendar/helpers/prefixPN';
 
 const PrintCalendar = forwardRef(
   ({ programName, calendarConf, config, course, useAcademicCalendar }, ref) => {
     const [t] = useTranslateLoader(prefixPN('programList'));
+
+    const courseId = course?.id ?? course;
+    const courseDates = config.courseDates[courseId] ?? {};
+
+    // Handle year display based on course dates
+    let yearDisplay = '';
+    let courseIndex = '';
+
+    if (!course?.index && courseDates?.startDate && courseDates?.endDate) {
+      // Get the years from start and end dates
+      const startYear = new Date(courseDates.startDate).getFullYear();
+      const endYear = new Date(courseDates.endDate).getFullYear();
+
+      // Format the course index based on whether the years are different
+      yearDisplay = startYear === endYear ? `${startYear}` : `${startYear} - ${endYear}`;
+    }
+
+    // Set course index with year display if available, otherwise just use the index
+    courseIndex = course?.index ?? yearDisplay;
 
     return (
       <Box style={{ display: 'none' }}>
@@ -26,7 +48,7 @@ const PrintCalendar = forwardRef(
         >
           <Box style={{ marginTop: 16 }}>
             <Title order={2}>{`${t('calendarOf')} ${programName} - ${
-              config.allCoursesHaveSameDates ? t('allCourses') : `${t('course')} ${course.index}`
+              config.allCoursesHaveSameDates ? t('allCourses') : `${t('course')} ${courseIndex}`
             }`}</Title>
           </Box>
           <Box style={{ marginTop: 32 }}>

--- a/plugins/leemons-plugin-academic-calendar/frontend/src/pages/private/program/components/Step3.js
+++ b/plugins/leemons-plugin-academic-calendar/frontend/src/pages/private/program/components/Step3.js
@@ -1,26 +1,20 @@
-import React, { useRef } from 'react';
+import { useReactToPrint } from 'react-to-print';
+
+import { BigCalendar } from '@bubbles-ui/calendars';
+import { Box, Button, ContextContainer, Stack, TabPanel, Tabs } from '@bubbles-ui/components';
+import { ChevLeftIcon, DownloadIcon } from '@bubbles-ui/icons/outline';
+import { useLocale, useStore } from '@common';
+import useRequestErrorMessage from '@common/useRequestErrorMessage';
+import { addErrorAlert, addSuccessAlert } from '@layout/alert';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import { BigCalendar } from '@bubbles-ui/calendars';
-import { ChevLeftIcon, DownloadIcon } from '@bubbles-ui/icons/outline';
-import {
-  Box,
-  Button,
-  ContextContainer,
-  Stack,
-  TabPanel,
-  Tabs,
-  IconButton,
-} from '@bubbles-ui/components';
-import { useLocale, useStore } from '@common';
-import { useProcessCalendarConfigForBigCalendar } from '@academic-calendar/helpers/useProcessCalendarConfigForBigCalendar';
-import { addErrorAlert, addSuccessAlert } from '@layout/alert';
-import useRequestErrorMessage from '@common/useRequestErrorMessage';
-import { saveConfig } from '@academic-calendar/request/config';
-import CalendarKey from '@academic-calendar/components/CalendarKey';
-import ReactToPrint from 'react-to-print';
-import PrintCalendar from '@academic-calendar/components/PrintCalendar';
+
 import FooterContainer from './FooterContainer';
+
+import CalendarKey from '@academic-calendar/components/CalendarKey';
+import PrintCalendar from '@academic-calendar/components/PrintCalendar';
+import { useProcessCalendarConfigForBigCalendar } from '@academic-calendar/helpers/useProcessCalendarConfigForBigCalendar';
+import { saveConfig } from '@academic-calendar/request/config';
 
 export default function Step3({
   regionalConfigs,
@@ -37,6 +31,10 @@ export default function Step3({
   const [processCalendarConfigForBigCalendar] = useProcessCalendarConfigForBigCalendar();
   const [store, render] = useStore({
     saving: false,
+  });
+
+  const handlePrint = useReactToPrint({
+    contentRef: calendarRef,
   });
 
   const coursesForDates = config.allCoursesHaveSameDates ? [program?.courses[0]] : program?.courses;
@@ -120,14 +118,13 @@ export default function Step3({
             {t('previous')}
           </Button>
           <Stack spacing={4}>
-            <ReactToPrint
-              trigger={() => (
-                <Button leftIcon={<DownloadIcon height={16} width={16} />} variant="outline">
-                  {t('downloadPDF')}
-                </Button>
-              )}
-              content={() => calendarRef.current}
-            />
+            <Button
+              leftIcon={<DownloadIcon height={16} width={16} />}
+              variant="outline"
+              onClick={handlePrint}
+            >
+              {t('downloadPDF')}
+            </Button>
             <Button loading={store.saving} onClick={submit}>
               {t('finishLabel')}
             </Button>

--- a/plugins/leemons-plugin-calendar/frontend/package.json
+++ b/plugins/leemons-plugin-calendar/frontend/package.json
@@ -32,7 +32,7 @@
     "react-hook-form": "^7.46.1",
     "react-overlays": "^5.2.1",
     "react-router-dom": "^5.3.3",
-    "react-to-print": "^2.14.13",
+    "react-to-print": "^3.0.1",
     "rrule": "^2.6.8",
     "uncontrollable": "^8.0.4"
   },

--- a/plugins/leemons-plugin-calendar/frontend/src/pages/private/Calendar/index.js
+++ b/plugins/leemons-plugin-calendar/frontend/src/pages/private/Calendar/index.js
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import ReactToPrint from 'react-to-print';
+import { useReactToPrint } from 'react-to-print';
 
 import CalendarKey from '@academic-calendar/components/CalendarKey';
 import PrintCalendar from '@academic-calendar/components/PrintCalendar';
@@ -58,6 +58,10 @@ function Calendar({ session }) {
 
   const calendarRef = useRef();
   const userIsAdmin = currentProfileIsAdmin();
+
+  const handlePrint = useReactToPrint({
+    contentRef: calendarRef,
+  });
 
   const [transformEv, evLoading] = useTransformEvent();
   const [t] = useTranslateLoader(prefixPN('calendar'));
@@ -654,15 +658,11 @@ function Calendar({ session }) {
                       </Stack>
                     ) : null}
                     <Box>
-                      <ReactToPrint
-                        trigger={() => (
-                          <IconButton
-                            icon={<DownloadIcon height={16} width={16} />}
-                            color="primary"
-                            rounded
-                          />
-                        )}
-                        content={() => calendarRef.current}
+                      <IconButton
+                        icon={<DownloadIcon height={16} width={16} />}
+                        color="primary"
+                        rounded
+                        onClick={handlePrint}
                       />
                     </Box>
                   </Stack>

--- a/plugins/leemons-plugin-content-creator/backend/core/document/getDocument.js
+++ b/plugins/leemons-plugin-content-creator/backend/core/document/getDocument.js
@@ -9,15 +9,19 @@ async function getDocument({ id, ctx }) {
 
   const ids = _.isArray(id) ? id : [id];
 
-  const assignables = await Promise.all(
+  const assignablesResult = await Promise.all(
     _.map(ids, (_id) =>
       ctx.tx.call('assignables.assignables.getAssignable', { id: _id, withFiles: true })
     )
   );
 
+  const assignables = _.compact(assignablesResult); // Remove undefined values
+
   const imagesIds = [];
   _.forEach(assignables, (assignable) => {
-    if (assignable.metadata.featuredImage) imagesIds.push(assignable.metadata.featuredImage);
+    if (assignable?.metadata?.featuredImage) {
+      imagesIds.push(assignable.metadata.featuredImage);
+    }
   });
 
   const documentAssets = await ctx.tx.call('leebrary.assets.getByIds', {
@@ -35,19 +39,22 @@ async function getDocument({ id, ctx }) {
   const result = _.map(assignables, (assignable) => ({
     id: assignable.id,
     asset: assignable.asset,
-    name: assignable.asset.name,
-    file: assignable.asset.file,
-    tags: assignable.asset.tags,
-    color: assignable.asset.color,
-    cover: assignable.asset.cover,
-    tagline: assignable.asset.tagline,
-    featuredImage: documentAssetsById[assignable.metadata.featuredImage],
-    description: assignable.asset.description,
+    name: assignable.asset?.name,
+    file: assignable.asset?.file,
+    tags: assignable.asset?.tags,
+    color: assignable.asset?.color,
+    cover: assignable.asset?.cover,
+    tagline: assignable.asset?.tagline,
+    featuredImage: assignable?.metadata?.featuredImage
+      ? documentAssetsById[assignable.metadata.featuredImage]
+      : null,
+    description: assignable.asset?.description,
     introductoryText: assignable.statement,
     content: documentsById[assignable.id]?.content,
     subjects: assignable.subjects,
     published: assignable.published,
   }));
+
   return _.isArray(id) ? result : result[0];
 }
 

--- a/plugins/leemons-plugin-content-creator/frontend/src/components/AssetMetadataContentCreator/AssetMetadataContentCreator.js
+++ b/plugins/leemons-plugin-content-creator/frontend/src/components/AssetMetadataContentCreator/AssetMetadataContentCreator.js
@@ -1,16 +1,18 @@
 /* eslint-disable sonarjs/cognitive-complexity */
-import React from 'react';
 import { Box, Text, TextClamp } from '@bubbles-ui/components';
 import useTranslateLoader from '@multilanguage/useTranslateLoader';
-import useDocument from '@content-creator/request/hooks/queries/useDocument';
-import prefixPN from '@content-creator/helpers/prefixPN';
-import extractH1AndH2Content from '@content-creator/helpers/extractH1AndH2Content';
-import { AssetMetadataContentCreatorStyles } from './AssetMetadataContentCreator.styles';
+
+import { ContentCreatorCardIcon } from '../icons/ContentCreatorCardIcon';
+
 import {
   ASSET_METADATA_CONTENT_CREATOR_DEFAULT_PROPS,
   ASSET_METADATA_CONTENT_CREATOR_PROP_TYPES,
 } from './AssetMetadataContentCreator.constants';
-import { ContentCreatorCardIcon } from '../icons/ContentCreatorCardIcon';
+import { AssetMetadataContentCreatorStyles } from './AssetMetadataContentCreator.styles';
+
+import extractH1AndH2Content from '@content-creator/helpers/extractH1AndH2Content';
+import prefixPN from '@content-creator/helpers/prefixPN';
+import useDocument from '@content-creator/request/hooks/queries/useDocument';
 
 const AssetMetadataContentCreator = ({ metadata }) => {
   const [t] = useTranslateLoader(prefixPN('contentCreatorDetail'));
@@ -20,8 +22,11 @@ const AssetMetadataContentCreator = ({ metadata }) => {
     { name: 'AssetMetadataContentCreator' }
   );
 
+  const assetId = metadata?.providerData?.id;
+
   const { data: documentData } = useDocument({
-    id: metadata?.providerData?.id,
+    id: assetId,
+    enabled: !!assetId,
   });
   const getH1andH2 = (document) => {
     if (documentData) {

--- a/plugins/leemons-plugin-content-creator/frontend/src/components/PrintContentButton/PrintContentButton.js
+++ b/plugins/leemons-plugin-content-creator/frontend/src/components/PrintContentButton/PrintContentButton.js
@@ -1,5 +1,5 @@
-import React, { useRef } from 'react';
-import ReactToPrint from 'react-to-print';
+import React, { useMemo, useRef } from 'react';
+import { useReactToPrint } from 'react-to-print';
 
 import { Box, Button } from '@bubbles-ui/components';
 import { DownloadIcon } from '@bubbles-ui/icons/solid';
@@ -17,33 +17,54 @@ const PrintContentButton = ({ content, title, assetId, variant = 'button', onTri
   const { classes } = ContentToPrintStyles({}, { name: 'ContentToPrint' });
   const [t] = useTranslateLoader(prefixPN('printContentButton'));
 
-  const { data: documentData } = useDocument(
-    {
-      id: assetId,
-      isNew: false,
-    },
-    { enabled: !!assetId }
-  );
+  const { data: documentData } = useDocument({
+    id: assetId,
+    isNew: false,
+    enabled: !!assetId,
+  });
 
-  const contentToProcess = documentData?.content ?? content;
-  const processedContent = processContentForPDF(contentToProcess, t);
-  const printRef = useRef();
-  const printInstance = useRef();
+  const processedContent = useMemo(() => {
+    const contentToProcess = documentData?.content ?? content;
+    if (!contentToProcess) {
+      return null;
+    }
+    return processContentForPDF(contentToProcess, t);
+  }, [documentData, content, t]);
 
-  const handlePrint = () => {
-    printInstance.current?.click();
-  };
+  const printRef = useRef(null);
+
+  const handlePrint = useReactToPrint({
+    contentRef: printRef,
+    documentTitle: title ?? '',
+    removeAfterPrint: true,
+  });
 
   React.useEffect(() => {
     if (onTrigger) {
       onTrigger(handlePrint);
     }
-  }, [onTrigger]);
+  }, [onTrigger, handlePrint]);
 
   const variantType = {
-    button: <Button variant="outline">{t('printPDF')}</Button>,
-    icon: <DownloadIcon width={18} height={18} color="#2F463F" />,
+    button: (
+      <Button variant="outline" onClick={handlePrint}>
+        {t('printPDF')}
+      </Button>
+    ),
+    icon: (
+      <DownloadIcon
+        width={18}
+        height={18}
+        color="#2F463F"
+        onClick={handlePrint}
+        style={{ cursor: 'pointer' }}
+      />
+    ),
   };
+
+  if (!processedContent) {
+    return null;
+  }
 
   return (
     <>
@@ -56,16 +77,7 @@ const PrintContentButton = ({ content, title, assetId, variant = 'button', onTri
           compact
         />
       </Box>
-      <ReactToPrint
-        trigger={(props) => (
-          <span {...props} ref={printInstance}>
-            {variantType[variant]}
-          </span>
-        )}
-        content={() => printRef.current}
-        documentTitle={title ?? ''}
-        removeAfterPrint
-      />
+      {variantType[variant]}
     </>
   );
 };

--- a/plugins/leemons-plugin-content-creator/frontend/src/request/hooks/queries/useDocument.js
+++ b/plugins/leemons-plugin-content-creator/frontend/src/request/hooks/queries/useDocument.js
@@ -1,24 +1,32 @@
-import { getDocumentRequest } from '@content-creator/request';
 import { useVariantForQueryKey } from '@common/queries';
 import { useQuery } from '@tanstack/react-query';
+
 import { getDocumentKey } from '../keys/document';
 
+import { getDocumentRequest } from '@content-creator/request';
+
 export default function useDocument({ id, isNew, ...options }) {
-  if (isNew) {
-    return { data: null, isLoading: false };
-  }
-
   const queryKey = getDocumentKey(id);
-
-  const queryFn = () => getDocumentRequest(id).then((response) => response.document);
 
   useVariantForQueryKey(queryKey, {
     modificationTrend: 'frequently',
   });
 
-  return useQuery({
+  const queryFn = async () => {
+    const response = await getDocumentRequest(id);
+    return response?.document ?? null;
+  };
+
+  const query = useQuery({
     ...options,
     queryKey,
     queryFn,
+    enabled: !!id && !isNew && options.enabled !== false,
   });
+
+  if (isNew) {
+    return { data: null, isLoading: false };
+  }
+
+  return query;
 }

--- a/plugins/leemons-plugin-content-creator/frontend/src/widgets/assignables/AssignmentDrawer.js
+++ b/plugins/leemons-plugin-content-creator/frontend/src/widgets/assignables/AssignmentDrawer.js
@@ -1,6 +1,6 @@
-import React, { useCallback } from 'react';
-import PropTypes from 'prop-types';
+import { useCallback } from 'react';
 import { useForm, FormProvider, Controller } from 'react-hook-form';
+
 import { useFormLocalizations } from '@assignables/components/Assignment/Form';
 import { Instructions } from '@assignables/components/Assignment/components/Instructions';
 import {
@@ -10,6 +10,7 @@ import {
   ContextContainer,
   TotalLayoutFooterContainer,
 } from '@bubbles-ui/components';
+import PropTypes from 'prop-types';
 
 export const useAssignmentDrawerStyles = createStyles(() => ({
   buttons: {

--- a/plugins/leemons-plugin-content-creator/frontend/src/widgets/leebrary/DocumentDetail.js
+++ b/plugins/leemons-plugin-content-creator/frontend/src/widgets/leebrary/DocumentDetail.js
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import { useHistory } from 'react-router-dom';
 
 import { useIsStudent } from '@academic-portfolio/hooks';

--- a/plugins/leemons-plugin-content-creator/frontend/src/widgets/leebrary/DocumentListCard.js
+++ b/plugins/leemons-plugin-content-creator/frontend/src/widgets/leebrary/DocumentListCard.js
@@ -115,7 +115,7 @@ const DocumentListCard = ({ asset, selected, onRefresh, onShare, ...props }) => 
     items.push({
       icon: (
         <PrintContentButton
-          assetId={asset.id}
+          assetId={asset.providerData?.id ?? asset.id}
           title={asset.name}
           variant="icon"
           onTrigger={(trigger) => {

--- a/plugins/leemons-plugin-content-creator/frontend/src/widgets/leebrary/DocumentPlayer.js
+++ b/plugins/leemons-plugin-content-creator/frontend/src/widgets/leebrary/DocumentPlayer.js
@@ -1,11 +1,10 @@
-import React from 'react';
 import { Box } from '@bubbles-ui/components';
-import useDocument from '@content-creator/request/hooks/queries/useDocument';
 import ContentEditorInput from '@common/components/ContentEditorInput/ContentEditorInput';
 import useTranslateLoader from '@multilanguage/useTranslateLoader';
 import propTypes from 'prop-types';
 
 import prefixPN from '@content-creator/helpers/prefixPN';
+import useDocument from '@content-creator/request/hooks/queries/useDocument';
 
 function DocumentPlayer({ asset }) {
   const { data: document } = useDocument({ id: asset?.providerData?.id });

--- a/plugins/leemons-plugin-fundae/frontend/package.json
+++ b/plugins/leemons-plugin-fundae/frontend/package.json
@@ -14,7 +14,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^5.3.3",
-    "react-to-print": "^2.14.13"
+    "react-to-print": "^3.0.1"
   },
   "devDependencies": {}
 }

--- a/plugins/leemons-plugin-fundae/frontend/src/pages/private/reports/index.js
+++ b/plugins/leemons-plugin-fundae/frontend/src/pages/private/reports/index.js
@@ -1,3 +1,6 @@
+import React from 'react';
+import { useReactToPrint } from 'react-to-print';
+
 import { SelectCourse, SelectProgram } from '@academic-portfolio/components/Selectors';
 import { getProfilesRequest, listCoursesRequest } from '@academic-portfolio/request';
 import {
@@ -18,8 +21,9 @@ import {
 } from '@bubbles-ui/components';
 import { DownloadIcon } from '@bubbles-ui/icons/outline';
 import { AlertWarningTriangleIcon } from '@bubbles-ui/icons/solid';
-// TODO: import from @common plugin
 import { AdminPageHeader } from '@bubbles-ui/leemons';
+
+// TODO: import from @common plugin
 import { LocaleDate, useStore } from '@common';
 import prefixPN from '@fundae/helpers/prefixPN';
 import { Pdf } from '@fundae/pages/private/reports/pdf';
@@ -30,8 +34,6 @@ import useTranslateLoader from '@multilanguage/useTranslateLoader';
 import { SelectCenter } from '@users/components';
 import SelectUserAgent from '@users/components/SelectUserAgent';
 import _ from 'lodash';
-import React from 'react';
-import { useReactToPrint } from 'react-to-print';
 
 function toDate(a) {
   if (a) {
@@ -55,7 +57,7 @@ export default function Index() {
   });
 
   store.handlePrint = useReactToPrint({
-    content: () => printRef.current,
+    contentRef: printRef,
     documentTitle: `${t('report')} - ${store.downloadReport?.userAgentName} - ${toDate(
       store.downloadReport?.createdAt
     )}`,

--- a/plugins/leemons-plugin-leebrary/frontend/src/components/LibraryDetailToolbar/LibraryDetailToolbar.js
+++ b/plugins/leemons-plugin-leebrary/frontend/src/components/LibraryDetailToolbar/LibraryDetailToolbar.js
@@ -135,7 +135,9 @@ const LibraryDetailToolbar = ({
           )}
           {toolbarItems.printPDF && (
             <ActionButton
-              icon={<PrintContentButton variant="icon" assetId={item.id} />}
+              icon={
+                <PrintContentButton variant="icon" assetId={item.providerData?.id ?? item.id} />
+              }
               tooltip={toolbarItems.printPDF}
               className={classes.button}
             />

--- a/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/PageFooter/PrintReportButton/PrintReportButton.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/MyScores/components/PageFooter/PrintReportButton/PrintReportButton.js
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import ReactToPrint from 'react-to-print';
+import { useReactToPrint } from 'react-to-print';
 
 import { Box, Button } from '@bubbles-ui/components';
 import useTranslateLoader from '@multilanguage/useTranslateLoader';
@@ -18,21 +18,21 @@ const PrintReportButton = ({ title }) => {
 
   const printRef = useRef();
 
+  const handlePrint = useReactToPrint({
+    contentRef: printRef,
+    documentTitle: title ?? '',
+    removeAfterPrint: true,
+  });
+
   return (
     <>
       <Box style={{ display: 'none' }}>
         <ReportCard ref={printRef} onLoading={setIsLoading} />
       </Box>
-      <ReactToPrint
-        trigger={(props) => (
-          <Button {...props} loading={isLoading}>
-            {t('downloadReport')}
-          </Button>
-        )}
-        content={() => printRef.current}
-        documentTitle={title ?? ''}
-        removeAfterPrint
-      />
+
+      <Button onClick={handlePrint} loading={isLoading}>
+        {t('downloadReport')}
+      </Button>
     </>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -23753,11 +23753,6 @@ react-textarea-autosize@8.3.4:
     use-composed-ref "^1.3.0"
     use-latest "^1.2.1"
 
-react-to-print@^2.14.13:
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/react-to-print/-/react-to-print-2.15.1.tgz#c9a6732cadf1118fc90d886b54a9388c419561b9"
-  integrity sha512-1foogIFbCpzAVxydkhBiDfMiFYhIMphiagDOfcG4X/EcQ+fBPqJ0rby9Wv/emzY1YLkIQy/rEgOrWQT+rBKhjw==
-
 react-to-print@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/react-to-print/-/react-to-print-3.0.1.tgz#feec2575073dbd15b28e4006f80a57043fd08e0a"


### PR DESCRIPTION
- Upgrade `react-to-print` from version 2.14.13 to 3.0.1 across multiple plugins.
- Refactor print components to utilize the new `useReactToPrint` hook for improved functionality and cleaner code.
- Update print handling in `PrintCalendar`, `Step3`, `Calendar`, `PrintContentButton`, and `PrintReportButton` components to enhance user experience.