### PR TITLE
fix(tasks): improve filesArray computation for better clarity

### DIFF
--- a/plugins/leemons-plugin-tasks/frontend/src/components/Student/TaskDetail/components/SubmissionStep/components/File/File.js
+++ b/plugins/leemons-plugin-tasks/frontend/src/components/Student/TaskDetail/components/SubmissionStep/components/File/File.js
@@ -59,7 +59,10 @@ function File({ assignation, preview }) {
   const [t] = useTranslateLoader(prefixPN('task_realization.submission_file'));
 
   const files = useFileUploadStore((state) => state.files);
-  const filesArray = useMemo(() => files?.values()?.toArray() ?? [], [files]);
+  const filesArray = useMemo(() => {
+    // Convert Map values iterator to array using Array.from
+    return files ? Array.from(files.values()) : [];
+  }, [files]);
 
   const { addNewFiles, removeMissingFiles, updateLeebraryId, changeStatus } = useFileUploadStore(
     (state) => state.actions


### PR DESCRIPTION
- Refactor the `filesArray` computation to use `Array.from` for converting the Map values iterator to an array. This change enhances code readability and maintains the fallback to an empty array when `files` is null or undefined.
- This update ensures that the file submission component remains robust and clear in its implementation.