### PR TITLE
feat(scores): Enhance ManualActivity functionality and update ScoresBasicTable

### DIFF
--- a/plugins/leemons-plugin-scores/backend/services/rest/manualActivities.rest.js
+++ b/plugins/leemons-plugin-scores/backend/services/rest/manualActivities.rest.js
@@ -71,6 +71,8 @@ const restActions = {
 
       return {
         ...updated,
+        classId: manualActivity?.classId,
+        id,
         status: 200,
       };
     },

--- a/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/ManualActivityDrawer/ManualActivityDrawer.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/EvaluationNotebook/components/ManualActivityDrawer/ManualActivityDrawer.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 import useRolesLocalizations from '@assignables/hooks/useRolesLocalizations';
@@ -13,6 +13,7 @@ import {
   Text,
   Select,
 } from '@bubbles-ui/components';
+import useCommonTranslate from '@multilanguage/helpers/useCommonTranslate';
 import useTranslateLoader from '@multilanguage/useTranslateLoader';
 import { capitalize } from 'lodash';
 import PropTypes from 'prop-types';
@@ -23,6 +24,7 @@ import useWeights from '@scores/requests/hooks/queries/useWeights';
 const defaultValues = { date: null, name: '', description: '' };
 
 export function ManualActivityDrawer({
+  activity,
   isOpen,
   classId,
   onClose: _onClose,
@@ -31,14 +33,27 @@ export function ManualActivityDrawer({
   maxDate,
 }) {
   const [t] = useTranslateLoader(prefixPN('manualActivityDrawer'));
+  const [tEval] = useTranslateLoader(prefixPN('evaluationNotebook'));
+  const { t: tCommon } = useCommonTranslate('formWithTheme');
   const [weightT] = useTranslateLoader(prefixPN('weightingTypes'));
-  const form = useForm({ defaultValues });
+
+  const form = useForm({
+    defaultValues,
+  });
   const [isLoading, setIsLoading] = useState(false);
 
-  const { data: weights } = useWeights({ classId });
+  const { data: weights } = useWeights({ classId, enabled: !!classId });
   const isRolesOrActivitiesWeight = weights?.type === 'roles' || weights?.type === 'activities';
 
   const rolesLocalizations = useRolesLocalizations(['task', 'test']);
+
+  useEffect(() => {
+    if (activity) {
+      form.setValue('date', new Date(activity?.deadline));
+      form.setValue('name', activity?.name ?? '');
+      form.setValue('description', activity?.description ?? '');
+    }
+  }, [activity]);
 
   const onClose = () => {
     _onClose();
@@ -56,7 +71,9 @@ export function ManualActivityDrawer({
 
   return (
     <Drawer opened={isOpen} onClose={onClose}>
-      <Drawer.Header title={t('title')} />
+      <Drawer.Header
+        title={activity ? `${tCommon('edit')} - ${tEval('filters.manualActivity')}` : t('title')}
+      />
 
       <Drawer.Content>
         <ContextContainer title={t('config')}>
@@ -73,6 +90,7 @@ export function ManualActivityDrawer({
                   required
                   minDate={minDate}
                   maxDate={maxDate}
+                  disabled={!!activity}
                 />
               </Box>
             )}
@@ -122,6 +140,7 @@ export function ManualActivityDrawer({
                   <Select
                     {...field}
                     label={t('roles')}
+                    disabled={!!activity}
                     data={[
                       {
                         value: 'task',
@@ -148,7 +167,7 @@ export function ManualActivityDrawer({
         </Drawer.Footer.LeftActions>
         <Drawer.Footer.RightActions>
           <Button onClick={handleSubmit} loading={isLoading}>
-            {t('save')}
+            {activity ? tCommon('save') : t('save')}
           </Button>
         </Drawer.Footer.RightActions>
       </Drawer.Footer>
@@ -163,4 +182,5 @@ ManualActivityDrawer.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   minDate: PropTypes.instanceOf(Date),
   maxDate: PropTypes.instanceOf(Date),
+  activity: PropTypes.object,
 };

--- a/plugins/leemons-plugin-scores/frontend/src/components/Tables/ScoresBasicTable/ActivityHeader/ActivityHeader.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/Tables/ScoresBasicTable/ActivityHeader/ActivityHeader.js
@@ -7,11 +7,16 @@ import {
   useHover,
   ActionButton,
 } from '@bubbles-ui/components';
-import { DeleteBinIcon, MoveLeftIcon, MoveRightIcon } from '@bubbles-ui/icons/outline';
-import { AlertWarningTriangleIcon, CutStarIcon } from '@bubbles-ui/icons/solid';
+import { MoveLeftIcon, MoveRightIcon } from '@bubbles-ui/icons/outline';
+import {
+  AlertWarningTriangleIcon,
+  CutStarIcon,
+  DeleteBinIcon,
+  EditWriteIcon,
+} from '@bubbles-ui/icons/solid';
 import { useLayout } from '@layout/context';
 import useTranslateLoader from '@multilanguage/useTranslateLoader';
-import { isFunction } from 'lodash';
+import { isFunction, noop } from 'lodash';
 
 import {
   ACTIVIY_HEADER_DEFAULT_PROPS,
@@ -32,6 +37,7 @@ const ActivityHeader = ({
   isExpanded,
   locale,
   onColumnExpand,
+  onEdit = noop,
   position,
   type,
   roleIcon,
@@ -65,7 +71,7 @@ const ActivityHeader = ({
     <Box ref={ref} className={classes.root}>
       <Box className={classes.header}>
         {isManualActivity && (
-          <Box className={classes.removeIcon}>
+          <Stack className={classes.removeIcon}>
             <ActionButton
               icon={<DeleteBinIcon width={18} height={18} />}
               onClick={() =>
@@ -80,7 +86,8 @@ const ActivityHeader = ({
                 })()
               }
             />
-          </Box>
+            <ActionButton icon={<EditWriteIcon width={18} height={18} />} onClick={onEdit} />
+          </Stack>
         )}
         <Stack spacing={2}>
           {roleIcon && (

--- a/plugins/leemons-plugin-scores/frontend/src/components/Tables/ScoresBasicTable/ScoresBasicTable.js
+++ b/plugins/leemons-plugin-scores/frontend/src/components/Tables/ScoresBasicTable/ScoresBasicTable.js
@@ -3,9 +3,11 @@ import { useTable, useFlexLayout } from 'react-table';
 import { useSticky } from 'react-table-sticky';
 
 import { Box, Text, UserDisplayItem, useElementSize, Stack } from '@bubbles-ui/components';
+import { addErrorAlert } from '@layout/alert';
 import { motion } from 'framer-motion';
 import { isFunction, noop } from 'lodash';
 
+import { ManualActivityDrawer } from '../../EvaluationNotebook/components/ManualActivityDrawer';
 import { CommonTableStyles } from '../CommonTable.styles';
 
 import { ActivityHeader } from './ActivityHeader';
@@ -16,6 +18,8 @@ import {
 } from './ScoresBasicTable.constants';
 import { ScoresBasicTableStyles } from './ScoresBasicTable.styles';
 import { RightContent } from './components/RightContent';
+
+import { useUpdateManualActivityMutation } from '@scores/requests/hooks/mutations/useUpdateManualActivityMutation';
 
 const ScoresBasicTable = ({
   grades,
@@ -42,6 +46,7 @@ const ScoresBasicTable = ({
 }) => {
   const { ref: tableRef } = useElementSize(null);
   const [value, setValue] = useState(_value);
+  const [manualActivity, setManualActivity] = useState(null);
   const useNumbers = !grades.some((grade) => grade.letter);
 
   const [expandedColumn, setExpandedColumn] = useState(_expandedColumn);
@@ -54,6 +59,8 @@ const ScoresBasicTable = ({
   );
   const { classes: basicClasses } = ScoresBasicTableStyles({}, { name: 'ScoresBasicTable' });
   const classes = { ...commonClasses, ...basicClasses };
+
+  const { mutateAsync: updateManualActivity } = useUpdateManualActivityMutation();
 
   const onColumnExpandHandler = (columnId) => {
     isFunction(onColumnExpand) && onColumnExpand(columnId);
@@ -118,6 +125,11 @@ const ScoresBasicTable = ({
     return activitiesObject;
   };
 
+  function handleOpenManualActivity(activityId) {
+    const activity = activities.find((activity) => activity.id === activityId);
+    setManualActivity(activity);
+  }
+
   const getColumns = () => {
     const columns = [];
     columns.push({
@@ -160,6 +172,7 @@ const ScoresBasicTable = ({
           <ActivityHeader
             {...activity}
             completionPercentage={completionPercentage}
+            onEdit={() => handleOpenManualActivity(activity.id)}
             locale={locale}
             isExpandable={activity.expandable}
             isExpanded={expandedColumn === activity.id}
@@ -295,6 +308,24 @@ const ScoresBasicTable = ({
     setExpandedColumn(_expandedColumn);
   }, [_expandedColumn]);
 
+  const handleOnSubmitManualActivity = async (data) => {
+    try {
+      const activity = {
+        name: data.name,
+        description: data.description,
+        date: new Date(manualActivity.deadline),
+        role: manualActivity.role,
+        classId: manualActivity.classId,
+        id: manualActivity.id,
+      };
+      console.log('activity:', activity);
+      await updateManualActivity(activity);
+    } catch (e) {
+      addErrorAlert('Error', e.message);
+      throw e;
+    }
+  };
+
   const spring = {
     type: 'spring',
     stiffness: 100,
@@ -372,6 +403,13 @@ const ScoresBasicTable = ({
           onDelete={onDelete}
         />
       </Box>
+      <ManualActivityDrawer
+        classId={manualActivity?.classId}
+        activity={manualActivity}
+        isOpen={!!manualActivity}
+        onClose={() => setManualActivity(null)}
+        onSubmit={handleOnSubmitManualActivity}
+      />
     </Box>
   );
 };

--- a/plugins/leemons-plugin-scores/frontend/src/requests/hooks/mutations/useUpdateManualActivityMutation.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/hooks/mutations/useUpdateManualActivityMutation.js
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { classManualActivitiesKey } from '../keys/manualActivities';
+
+import { updateManualActivity } from '@scores/requests/manualActivities/update';
+
+export function useUpdateManualActivityMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateManualActivity,
+    onSuccess: (_, { classId }) => {
+      if (classId) {
+        queryClient.invalidateQueries({
+          queryKey: classManualActivitiesKey({ classId }),
+        });
+      }
+    },
+  });
+}

--- a/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/update.js
+++ b/plugins/leemons-plugin-scores/frontend/src/requests/manualActivities/update.js
@@ -11,6 +11,8 @@
 export function updateManualActivity({ id, ...manualActivity }) {
   return leemons.api(`v1/scores/manualActivities/${id}`, {
     method: 'PUT',
-    body: manualActivity,
+    body: {
+      manualActivity,
+    },
   });
 }


### PR DESCRIPTION
- Add `activity` prop to `ManualActivityDrawer` for editing existing activities.
- Implement `handleOpenManualActivity` in `ScoresBasicTable` to set the selected activity for editing.
- Introduce `useUpdateManualActivityMutation` for updating manual activities with proper query invalidation.
- Update `updateManualActivity` API call to correctly structure the request body.
- Refactor `ManualActivityDrawer` to pre-fill form fields when editing an activity.